### PR TITLE
Use `join-splat` pattern for outputs using resources with `count`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Cloud Posse, LLC
+   Copyright 2017-2018 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,25 +1,25 @@
 output "id" {
-  value       = "${null_resource.default.triggers.id}"
+  value       = "${join("", null_resource.default.*.triggers.id)}"
   description = "Disambiguated ID"
 }
 
 output "name" {
-  value       = "${null_resource.default.triggers.name}"
+  value       = "${join("", null_resource.default.*.triggers.name)}"
   description = "Normalized name"
 }
 
 output "namespace" {
-  value       = "${null_resource.default.triggers.namespace}"
+  value       = "${join("", null_resource.default.*.triggers.namespace)}"
   description = "Normalized namespace"
 }
 
 output "stage" {
-  value       = "${null_resource.default.triggers.stage}"
+  value       = "${join("", null_resource.default.*.triggers.stage)}"
   description = "Normalized stage"
 }
 
 output "attributes" {
-  value       = "${null_resource.default.triggers.attributes}"
+  value       = "${join("", null_resource.default.*.triggers.attributes)}"
   description = "Normalized attributes"
 }
 


### PR DESCRIPTION
## what
* Use `join-splat` pattern for outputs using resources with `count`

## why
* New `Terraform` versions complain if a resource with `count` is used in `outputs` without `splat` syntax
> Resource 'null_resource.default' not found for variable 'null_resource.default.triggers.id'

> Terraform will now detect and warn about outputs containing potentially-problematic references to resources with count set where the references does not use the "splat" syntax. This identifies situations where an output may reference a resource with count = 0 even if the count expression does not currently evaluate to 0, allowing the bug to be detected and fixed before the value is later changed to 0 and would thus become an error. This usage will become a fatal error in Terraform 0.12. (#16735)