### PR TITLE
Use `join`+`splat` pattern in `tags`

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -29,9 +29,9 @@ output "tags" {
   value = "${
       merge( 
         map(
-          "Name", "${null_resource.default.triggers.id}",
-          "Namespace", "${null_resource.default.triggers.namespace}",
-          "Stage", "${null_resource.default.triggers.stage}"
+          "Name", "${join("", null_resource.default.*.triggers.id)}",
+          "Namespace", "${join("", null_resource.default.*.triggers.namespace)}",
+          "Stage", "${join("", null_resource.default.*.triggers.stage)}"
         ), var.tags
       )
     }"


### PR DESCRIPTION
## what
* Use `join`+`splat` pattern in `tags`

## why
* New `Terraform` versions complain if a resource with `count` is used in `outputs` without `splat` syntax

> Terraform will now detect and warn about outputs containing potentially-problematic references to resources with count set where the references does not use the "splat" syntax. This identifies situations where an output may reference a resource with count = 0 even if the count expression does not currently evaluate to 0, allowing the bug to be detected and fixed before the value is later changed to 0 and would thus become an error. This usage will become a fatal error in Terraform 0.12. (#16735)