### PR TITLE
Fix quote typo breaking syntax coloration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ resource "aws_security_group" "eg_prod_bastion_abc" {
 resource "aws_instance" "eg_prod_bastion_abc" {
    instance_type          = "t1.micro"
    tags                   = "${module.eg_prod_bastion_abc_label.tags}"
-   vpc_security_group_ids = ["${aws_security_group.eg_prod_bastion_abc.id"}]
+   vpc_security_group_ids = ["${aws_security_group.eg_prod_bastion_abc.id}"]
 }
 
 module "eg_prod_bastion_xyz_label" {


### PR DESCRIPTION
## what 
* Fix quote typo breaking syntax coloration in README 

## why
* Syntax coloration started looking funny at some point, which I traced down to this little change.