### PR TITLE
[Feature] slim down to null_data_source and `exclude_label_tags`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,11 @@ variable "enabled" {
   default     = "true"
 }
 
+variable "exclude_generated_tags" {
+  description = "Set to true to exclude generated tags: Name/Namespace/Stage."
+  default     = false
+}
+
 variable "delimiter" {
   type        = "string"
   default     = "-"


### PR DESCRIPTION
Motivation is to provide an abstract base for other null_labels.

```hcl
/* some tf file */
module "project" {
  ...
  user_tags_only = true
  tags = {
    ManagedBy = "terraform"
    Foo = "bar"
  }
}

/* using an abstract base to initialize with inherited tags */
module "kops" {
   name = "kops"
   namespace = "${module.project.namespace}"
   stage = "${module.project.stage}"
   tags = "${module.project.tags}
}
```
