### PR TITLE
Added missing environment output

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Available targets:
 | attributes | Normalized attributes |
 | context | Context of this module to pass between other modules |
 | delimiter | Delimiter used in label ID |
+| environment | Normalized environment |
 | id | Disambiguated ID |
 | name | Normalized name |
 | namespace | Normalized namespace |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,6 +21,7 @@
 | attributes | Normalized attributes |
 | context | Context of this module to pass between other modules |
 | delimiter | Delimiter used in label ID |
+| environment | Normalized environment |
 | id | Disambiguated ID |
 | name | Normalized name |
 | namespace | Normalized namespace |

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "stage" {
   description = "Normalized stage"
 }
 
+output "environment" {
+  value       = "${local.enabled ? local.environment : ""}"
+  description = "Normalized environment"
+}
+
 output "attributes" {
   value       = "${local.enabled ? local.attributes : ""}"
   description = "Normalized attributes"


### PR DESCRIPTION
## what
The output for `environment` is missing.
## why
All inputs should be outputs.