### PR TITLE
fixes typo/reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module "eg_prod_bastion_label" {
 }
 ```
 
-This will create an `id` with the value of `eg-prod-bastion-public`.
+This will create an `id` with the value of `eg_prod_bastion_label`.
 
 Now reference the label when creating an instance:
 


### PR DESCRIPTION
README references `eg-prod-bastion-public` resource that doesn't exist yet in the step where it's mentioned. i believe `eg-prod-bastion-label` is intended here.

Signed-off-by: camilo santana <camilo.santana@procore.com>