### PR TITLE
Fix tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Cloud Posse](https://cloudposse.com/logo-300x69.svg)](https://cloudposse.com)
 
-# terraform-null-label [![Build Status](https://travis-ci.org/cloudposse/terraform-null-label.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-null-label-cloudtrail) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-null-label.svg)](https://github.com/cloudposse/terraform-null-label/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+# terraform-null-label [![Build Status](https://travis-ci.org/cloudposse/terraform-null-label.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-null-label) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-null-label.svg)](https://github.com/cloudposse/terraform-null-label/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 
 Terraform module designed to generate consistent label names and tags for resources. Use `terraform-null-label` to implement a strict naming convention.

--- a/README.md
+++ b/README.md
@@ -401,9 +401,9 @@ Available targets:
 
 | Name | Description |
 |------|-------------|
-| attributes | Normalized attributes |
-| context | Context of this module to pass between other modules |
-| delimiter | Delimiter used in label ID |
+| attributes | List of attributes |
+| context | Context of this module to pass to other label modules |
+| delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
 | environment | Normalized environment |
 | id | Disambiguated ID |
 | label_order | The naming order of the id output and Name tag |

--- a/README.yaml
+++ b/README.yaml
@@ -20,7 +20,7 @@ github_repo: cloudposse/terraform-null-label
 badges:
   - name: "Build Status"
     image: "https://travis-ci.org/cloudposse/terraform-null-label.svg?branch=master"
-    url: "https://travis-ci.org/cloudposse/terraform-null-label-cloudtrail"
+    url: "https://travis-ci.org/cloudposse/terraform-null-label"
   - name: "Latest Release"
     image: "https://img.shields.io/github/release/cloudposse/terraform-null-label.svg"
     url: "https://github.com/cloudposse/terraform-null-label/releases/latest"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,9 +19,9 @@
 
 | Name | Description |
 |------|-------------|
-| attributes | Normalized attributes |
-| context | Context of this module to pass between other modules |
-| delimiter | Delimiter used in label ID |
+| attributes | List of attributes |
+| context | Context of this module to pass to other label modules |
+| delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
 | environment | Normalized environment |
 | id | Disambiguated ID |
 | label_order | The naming order of the id output and Name tag |

--- a/main.tf
+++ b/main.tf
@@ -44,13 +44,11 @@ locals {
   delimiter                      = "${var.delimiter != "-" ? var.delimiter : local.delimiter_context_or_default}"
   # Merge attributes
   attributes = ["${distinct(compact(concat(var.attributes, local.context_local["attributes"])))}"]
-  # Generate tags
-  generated_tags = {
-    "Name"        = "${local.id}"
-    "Namespace"   = "${local.namespace}"
-    "Environment" = "${local.environment}"
-    "Stage"       = "${local.stage}"
-  }
+  # Generate tags (don't include tags with empty values)
+  generated_tags = "${zipmap(
+    compact(list("Name", local.namespace != "" ? "Namespace" : "", local.environment != "" ? "Environment" : "", local.stage != "" ? "Stage" : "")),
+    compact(list(local.id, local.namespace, local.environment, local.stage))
+    )}"
   tags                     = "${merge(zipmap(local.context_local["tags_keys"], local.context_local["tags_values"]), local.generated_tags, var.tags)}"
   tags_as_list_of_maps     = ["${data.null_data_source.tags_as_list_of_maps.*.outputs}"]
   label_order_default_list = "${list("namespace", "environment", "stage", "name", "attributes")}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,12 +25,12 @@ output "environment" {
 
 output "attributes" {
   value       = "${local.attributes}"
-  description = "Normalized attributes"
+  description = "List of attributes"
 }
 
 output "delimiter" {
   value       = "${local.enabled ? local.delimiter : ""}"
-  description = "Delimiter used in label ID"
+  description = "Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes`"
 }
 
 output "tags" {
@@ -45,7 +45,7 @@ output "tags_as_list_of_maps" {
 
 output "context" {
   value       = "${local.output_context}"
-  description = "Context of this module to pass between other modules"
+  description = "Context of this module to pass to other label modules"
 }
 
 output "label_order" {


### PR DESCRIPTION
## what
* Fix tags: don't include tags with empty values
* Fix Travis URL in `README`

## why
* Many resources (e.g. Elastic Beanstalk) fail if provided with tags with empty values

## references 
* closes #42

