### PR TITLE
Enable hyphens in `var.regex_replace_chars`

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Available targets:
 | label_order | The naming order of the id output and Name tag | list | `<list>` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
-| regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9]/` | no |
+| regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9-]/` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map | `<map>` | no |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -11,7 +11,7 @@
 | label_order | The naming order of the id output and Name tag | list | `<list>` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
-| regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9]/` | no |
+| regex_replace_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | string | `/[^a-zA-Z0-9-]/` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map | `<map>` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,6 @@ variable "label_order" {
 
 variable "regex_replace_chars" {
   type        = "string"
-  default     = "/[^a-zA-Z0-9]/"
-  description = "Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only letters and digits are allowed, all other chars are removed"
+  default     = "/[^a-zA-Z0-9-]/"
+  description = "Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed"
 }


### PR DESCRIPTION
## what
* Enable hyphens in `var.regex_replace_chars`

## why
* Many users want to use `-` in `name`, `namespace`, `stage`
* https://github.com/cloudposse/terraform-null-label/issues/49
* https://github.com/cloudposse/terraform-aws-tfstate-backend/issues/14
