### PR TITLE
Fixed filter out empty tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,9 +12,21 @@ locals {
   regex_replace_chars = coalesce(var.regex_replace_chars, var.context.regex_replace_chars)
 
   name                = lower(replace(coalesce(var.name, var.context.name), local.regex_replace_chars, local.defaults.replacement))
-  namespace           = lower(replace(coalesce(var.namespace, var.context.namespace), local.regex_replace_chars, local.defaults.replacement))
-  environment         = lower(replace(coalesce(var.environment, var.context.environment), local.regex_replace_chars, local.defaults.replacement))
-  stage               = lower(replace(coalesce(var.stage, var.context.stage), local.regex_replace_chars, local.defaults.replacement))
+  namespace           = (
+    var.namespace != "" || var.context.namespace != ""
+      ? lower(replace(coalesce(var.namespace, var.context.namespace), local.regex_replace_chars, local.defaults.replacement))
+      : ""
+  )
+  environment         = (
+    var.environment != "" || var.context.environment != ""
+      ? lower(replace(coalesce(var.environment, var.context.environment), local.regex_replace_chars, local.defaults.replacement))
+      : ""
+  )
+  stage               = (
+    var.stage != "" || var.context.stage != ""
+    ? lower(replace(coalesce(var.stage, var.context.stage), local.regex_replace_chars, local.defaults.replacement))
+    : ""
+  )
   delimiter           = coalesce(var.delimiter, var.context.delimiter, local.defaults.delimiter)
   label_order         = length(var.label_order) > 0 ? var.label_order : (length(var.context.label_order) > 0 ? var.context.label_order : local.defaults.label_order)
   additional_tag_map  = merge(var.context.additional_tag_map, var.additional_tag_map)


### PR DESCRIPTION
The filter wasn't working because of an issue with the `attributes`.
If they weren't set, then `keys(local.id_context)` will resulted in: `[null, "name", "environment", ...]`
The `null` value then made the for loop break, or at least resulted in `generated_tags` to be empty/null.

This seems to be a side effect of: `distinct()` on the list.
I've solved this by adding `all_attributes`, and check it's length within `id_context` to set the `attributes`.