### PR TITLE
Fix name tag and add test

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,10 +25,19 @@ locals {
   # Merge attributes
   attributes = compact(distinct(concat(var.attributes, var.context.attributes, local.defaults.attributes)))
 
-  generated_tags = { for l in keys(local.id_context) : title(l) => local.id_context[l] if length(local.id_context[l]) > 0 }
 
   tags                 = merge(var.context.tags, local.generated_tags, var.tags)
   tags_as_list_of_maps = data.null_data_source.tags_as_list_of_maps.*.outputs
+
+  tags_context = {
+    # For AWS we need `Name` to be disambiguated sine it has a special meaning 
+    name        = local.id
+    namespace   = local.namespace
+    environment = local.environment
+    stage       = local.stage
+    attributes  = local.id_context.attributes
+  }
+  generated_tags = { for l in keys(local.tags_context) : title(l) => local.tags_context[l] if length(local.tags_context[l]) > 0 }
 
   id_context = {
     name        = local.name

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -25,27 +25,35 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Run `terraform output` to get the value of an output variable
 	label1 := terraform.OutputMap(t, terraformOptions, "label1")
+	label1Tags := terraform.OutputMap(t, terraformOptions, "label1_tags")
 
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, "winstonchurchroom-uat-build-fire-water-earth-air", label1["id"])
+	assert.Equal(t, "winstonchurchroom-uat-build-fire-water-earth-air", label1Tags["Name"])
 
 	// Run `terraform output` to get the value of an output variable
 	label2 := terraform.OutputMap(t, terraformOptions, "label2")
+	label2Tags := terraform.OutputMap(t, terraformOptions, "label2_tags")
 
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, "charlie+uat+test+fire+water+earth+air", label2["id"])
+	assert.Equal(t, "charlie+uat+test+fire+water+earth+air", label2Tags["Name"])
 
 	// Run `terraform output` to get the value of an output variable
 	label3 := terraform.OutputMap(t, terraformOptions, "label3")
+	label3Tags := terraform.OutputMap(t, terraformOptions, "label3_tags")
 
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, "starfish.uat.release.fire.water.earth.air", label3["id"])
+	assert.Equal(t, "starfish.uat.release.fire.water.earth.air", label3Tags["Name"])
 
 	// Run `terraform output` to get the value of an output variable
 	label4 := terraform.OutputMap(t, terraformOptions, "label4")
+	label4Tags := terraform.OutputMap(t, terraformOptions, "label4_tags")
 
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, "cloudposse-uat-big-fat-honking-cluster", label4["id"])
+	assert.Equal(t, "cloudposse-uat-big-fat-honking-cluster", label4Tags["Name"])
 
 	// Run `terraform output` to get the value of an output variable
 	label5 := terraform.OutputMap(t, terraformOptions, "label5")


### PR DESCRIPTION
## what
* Fix regression introduced in #63 
* Update tests

## why
* `Name` tag has a special meaning in AWS, which is why it should be mapped to the `id`
* Closes #66 