### PR TITLE
Add `versions.tf`

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,0 @@
-provider "null" {
-  version = "~> 2.1"
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,7 @@
 terraform {
   required_version = "~> 0.12.0"
 }
+
+provider "null" {
+  version = "~> 2.1"
+}


### PR DESCRIPTION
## what
* Add `versions.tf`

## why
* Standardize on a file name to pin Terraform and provider versions
* The file with a standard name is easy to check manually by users and automatically by scripts
* `versions.tf` is also automatically added by `terraform 0.12upgrade` tool
