### PR TITLE
Use `required_providers` to pin Terraform providers

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = "~> 0.12.0"
-}
 
-provider "null" {
-  version = "~> 2.1"
+  required_providers {
+    null = "~> 2.0"
+  }
 }


### PR DESCRIPTION
## what
* Use `required_providers` to pin Terraform providers

## why
* Pinning the module's providers version in `required_providers` block allows specifying only the required provider version for the module without the need to specify all providers with versions explicitly
