### PR TITLE
Dropping null_resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,8 +664,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Sergey Vasilyev][s2504s_avatar]][s2504s_homepage]<br/>[Sergey Vasilyev][s2504s_homepage] | [![Michael Pereira][MichaelPereira_avatar]][MichaelPereira_homepage]<br/>[Michael Pereira][MichaelPereira_homepage] | [![Jamie Nelson][Jamie-BitFlight_avatar]][Jamie-BitFlight_homepage]<br/>[Jamie Nelson][Jamie-BitFlight_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Daren Desjardins][darend_avatar]][darend_homepage]<br/>[Daren Desjardins][darend_homepage] |
-|---|---|---|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Sergey Vasilyev][s2504s_avatar]][s2504s_homepage]<br/>[Sergey Vasilyev][s2504s_homepage] | [![Michael Pereira][MichaelPereira_avatar]][MichaelPereira_homepage]<br/>[Michael Pereira][MichaelPereira_homepage] | [![Jamie Nelson][Jamie-BitFlight_avatar]][Jamie-BitFlight_homepage]<br/>[Jamie Nelson][Jamie-BitFlight_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Daren Desjardins][darend_avatar]][darend_homepage]<br/>[Daren Desjardins][darend_homepage] | [![Maarten van der Hoef][maartenvanderhoef_avatar]][maartenvanderhoef_homepage]<br/>[Maarten van der Hoef][maartenvanderhoef_homepage] |
+|---|---|---|---|---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://github.com/osterman.png?size=150
@@ -683,6 +683,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [SweetOps_avatar]: https://github.com/SweetOps.png?size=150
   [darend_homepage]: https://github.com/darend
   [darend_avatar]: https://github.com/darend.png?size=150
+  [maartenvanderhoef_homepage]: https://github.com/maartenvanderhoef
+  [maartenvanderhoef_avatar]: https://github.com/maartenvanderhoef.png?size=150
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -509,3 +509,5 @@ contributors:
     github: "SweetOps"
   - name: "Daren Desjardins"
     github: "darend"
+  - name: "Maarten van der Hoef"
+    github: "maartenvanderhoef"

--- a/examples/complete/label2.tf
+++ b/examples/complete/label2.tf
@@ -6,6 +6,12 @@ module "label2" {
   delimiter           = "+"
   regex_replace_chars = "/[^a-zA-Z0-9-+]/"
 
+  additional_tag_map = {
+    propagate_at_launch = "true"
+    additional_tag      = "yes"
+  }
+
+
   tags = {
     "City"        = "London"
     "Environment" = "Public"
@@ -27,9 +33,10 @@ output "label2_tags" {
   value = module.label2.tags
 }
 
+output "label2_tags_as_list_of_maps" {
+  value = module.label2.tags_as_list_of_maps
+}
+
 output "label2_context" {
   value = module.label2.context
 }
-
-
-


### PR DESCRIPTION
## What

Replaced `null_resource` with Terraform 0.12 for-logic

## Why

No provider dependency, less resources.