### PR TITLE
Add check for tag map

### DIFF
--- a/examples/autoscalinggroup/main.tf
+++ b/examples/autoscalinggroup/main.tf
@@ -2,7 +2,7 @@
 # terraform-null-label example #
 ################################
 module "label" {
-  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=master"
+  source    = "../../"
   namespace = "cp"
   stage     = "prod"
   name      = "app"

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ locals {
 }
 
 data "null_data_source" "tags_as_list_of_maps" {
-  count = "${local.enabled ? length(keys(local.tags)) : 0}"
+  count = "${length(keys(var.additional_tag_map)) > 0 && local.enabled ? length(keys(local.tags)) : 0}"
 
   inputs = "${merge(map(
     "key", "${element(keys(local.tags), count.index)}",

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  enabled = "${var.enabled == "true" ? true : false }"
+  enabled = "${var.enabled == "true" || var.enabled == true ? true : false }"
 
   # Only maps that contain all the same attribute types can be merged, so the values have been set to list
   context_struct = {
@@ -88,7 +88,7 @@ locals {
 }
 
 data "null_data_source" "tags_as_list_of_maps" {
-  count = "${length(keys(var.additional_tag_map)) > 0 && local.enabled ? length(keys(local.tags)) : 0}"
+  count = "${length(keys(var.additional_tag_map)) > 0 && local.enabled == true ? length(keys(local.tags)) : 0}"
 
   inputs = "${merge(map(
     "key", "${element(keys(local.tags), count.index)}",


### PR DESCRIPTION
Updated 'enabled' flag to check for both 'true' and "true.
Updated the data source to only create a list of tags as maps if an additional tag map is supplied.