### PR TITLE
Add option to limit output id length

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ No provider.
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
 | label\_order | The naming order of the id output and Name tag | `list(string)` | `[]` | no |
+| max\_id\_length | Specify max length of output id result, or 0 for unrestricted length | `number` | `0` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | `string` | `"/[^a-zA-Z0-9-]/"` | no |
@@ -552,7 +553,8 @@ No provider.
 | context | Context of this module to pass to other label modules |
 | delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
 | environment | Normalized environment |
-| id | Disambiguated ID |
+| full\_id | Disambiguated ID not restricted to max\_id\_length |
+| id | Disambiguated ID restricted to max\_id\_length |
 | label\_order | The naming order of the id output and Name tag |
 | name | Normalized name |
 | namespace | Normalized namespace |
@@ -706,8 +708,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Sergey Vasilyev][s2504s_avatar]][s2504s_homepage]<br/>[Sergey Vasilyev][s2504s_homepage] | [![Michael Pereira][MichaelPereira_avatar]][MichaelPereira_homepage]<br/>[Michael Pereira][MichaelPereira_homepage] | [![Jamie Nelson][Jamie-BitFlight_avatar]][Jamie-BitFlight_homepage]<br/>[Jamie Nelson][Jamie-BitFlight_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Daren Desjardins][darend_avatar]][darend_homepage]<br/>[Daren Desjardins][darend_homepage] | [![Maarten van der Hoef][maartenvanderhoef_avatar]][maartenvanderhoef_homepage]<br/>[Maarten van der Hoef][maartenvanderhoef_homepage] |
-|---|---|---|---|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Sergey Vasilyev][s2504s_avatar]][s2504s_homepage]<br/>[Sergey Vasilyev][s2504s_homepage] | [![Michael Pereira][MichaelPereira_avatar]][MichaelPereira_homepage]<br/>[Michael Pereira][MichaelPereira_homepage] | [![Jamie Nelson][Jamie-BitFlight_avatar]][Jamie-BitFlight_homepage]<br/>[Jamie Nelson][Jamie-BitFlight_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Daren Desjardins][darend_avatar]][darend_homepage]<br/>[Daren Desjardins][darend_homepage] | [![Maarten van der Hoef][maartenvanderhoef_avatar]][maartenvanderhoef_homepage]<br/>[Maarten van der Hoef][maartenvanderhoef_homepage] | [![Adam Tibbing][tibbing_avatar]][tibbing_homepage]<br/>[Adam Tibbing][tibbing_homepage] |
+|---|---|---|---|---|---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
@@ -727,6 +729,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [darend_avatar]: https://img.cloudposse.com/150x150/https://github.com/darend.png
   [maartenvanderhoef_homepage]: https://github.com/maartenvanderhoef
   [maartenvanderhoef_avatar]: https://img.cloudposse.com/150x150/https://github.com/maartenvanderhoef.png
+  [tibbing_homepage]: https://github.com/tibbing
+  [tibbing_avatar]: https://img.cloudposse.com/150x150/https://github.com/tibbing.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -537,8 +537,8 @@ No provider.
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
+| id\_max\_length | Specify the max length of the `id` output, or 0 for unrestricted length | `number` | `0` | no |
 | label\_order | The naming order of the id output and Name tag | `list(string)` | `[]` | no |
-| max\_id\_length | Specify max length of output id result, or 0 for unrestricted length | `number` | `0` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | `string` | `"/[^a-zA-Z0-9-]/"` | no |
@@ -553,8 +553,8 @@ No provider.
 | context | Context of this module to pass to other label modules |
 | delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
 | environment | Normalized environment |
-| full\_id | Disambiguated ID not restricted to max\_id\_length |
-| id | Disambiguated ID restricted to max\_id\_length |
+| id | Disambiguated ID restricted to id\_max\_length |
+| id\_full | Disambiguated ID not restricted to id\_max\_length |
 | label\_order | The naming order of the id output and Name tag |
 | name | Normalized name |
 | namespace | Normalized namespace |

--- a/README.yaml
+++ b/README.yaml
@@ -481,3 +481,5 @@ contributors:
   github: darend
 - name: Maarten van der Hoef
   github: maartenvanderhoef
+- name: Adam Tibbing
+  github: tibbing

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,6 +19,7 @@ No provider.
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
 | label\_order | The naming order of the id output and Name tag | `list(string)` | `[]` | no |
+| max\_id\_length | Specify max length of output id result, or 0 for unrestricted length | `number` | `0` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | `string` | `"/[^a-zA-Z0-9-]/"` | no |
@@ -33,7 +34,8 @@ No provider.
 | context | Context of this module to pass to other label modules |
 | delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
 | environment | Normalized environment |
-| id | Disambiguated ID |
+| full\_id | Disambiguated ID not restricted to max\_id\_length |
+| id | Disambiguated ID restricted to max\_id\_length |
 | label\_order | The naming order of the id output and Name tag |
 | name | Normalized name |
 | namespace | Normalized namespace |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,8 +18,8 @@ No provider.
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
+| id\_max\_length | Specify the max length of the `id` output, or 0 for unrestricted length | `number` | `0` | no |
 | label\_order | The naming order of the id output and Name tag | `list(string)` | `[]` | no |
-| max\_id\_length | Specify max length of output id result, or 0 for unrestricted length | `number` | `0` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed | `string` | `"/[^a-zA-Z0-9-]/"` | no |
@@ -34,8 +34,8 @@ No provider.
 | context | Context of this module to pass to other label modules |
 | delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
 | environment | Normalized environment |
-| full\_id | Disambiguated ID not restricted to max\_id\_length |
-| id | Disambiguated ID restricted to max\_id\_length |
+| id | Disambiguated ID restricted to id\_max\_length |
+| id\_full | Disambiguated ID not restricted to id\_max\_length |
 | label\_order | The naming order of the id output and Name tag |
 | name | Normalized name |
 | namespace | Normalized namespace |

--- a/examples/autoscalinggroup/main.tf
+++ b/examples/autoscalinggroup/main.tf
@@ -64,7 +64,7 @@ resource "aws_autoscaling_group" "default" {
 # Provider                     #
 ################################
 provider "aws" {
-  region  = "eu-west-1"
+  region = "eu-west-1"
 
   # Make it faster by skipping unneeded checks here
   skip_get_ec2_platforms      = true

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,14 @@ locals {
 
   labels = [for l in local.label_order : local.id_context[l] if length(local.id_context[l]) > 0]
 
-  id = lower(join(local.delimiter, local.labels))
+  full_id = lower(join(local.delimiter, local.labels))
+  id_md5  = md5(local.full_id)
+  # Truncates ID to given max length, suffixed by 6 character hash of ID for disambiguation 
+  id_short = (var.max_id_length <= 6 ?
+    substr(local.id_md5, 0, var.max_id_length) :
+  "${replace(substr(local.full_id, 0, var.max_id_length - 6), "/-$/", "")}-${substr(local.id_md5, 0, 5)}")
+  id = var.max_id_length != 0 && length(local.full_id) > var.max_id_length ? local.id_short : local.full_id
+
 
   # Context of this label to pass to other label modules
   output_context = {

--- a/main.tf
+++ b/main.tf
@@ -56,13 +56,13 @@ locals {
 
   labels = [for l in local.label_order : local.id_context[l] if length(local.id_context[l]) > 0]
 
-  id_full = lower(join(local.delimiter, local.labels))
-  id_md5  = md5(local.id_full)
-  # Truncates ID to given max length, suffixed by 6 character hash of ID for disambiguation 
-  id_short = (var.max_id_length <= 6 ?
-    substr(local.id_md5, 0, var.max_id_length) :
-  "${replace(substr(local.id_full, 0, var.max_id_length - 6), "/-$/", "")}-${substr(local.id_md5, 0, 5)}")
-  id = var.max_id_length != 0 && length(local.id_full) > var.max_id_length ? local.id_short : local.id_full
+id_full = lower(join(local.delimiter, local.labels))
+id_md5  = md5(local.id_full)
+# Truncates ID to given max length, suffixed by 6 character hash of ID for disambiguation 
+id_short = (var.id_max_length <= 6 ?
+substr(local.id_md5, 0, var.id_max_length) :
+"${replace(substr(local.id_full, 0, var.id_max_length - 6), "/-$/", "")}-${substr(local.id_md5, 0, 5)}")
+id = var.id_max_length != 0 && length(local.id_full) > var.id_max_length ? local.id_short : local.id_full
 
 
   # Context of this label to pass to other label modules

--- a/main.tf
+++ b/main.tf
@@ -56,13 +56,13 @@ locals {
 
   labels = [for l in local.label_order : local.id_context[l] if length(local.id_context[l]) > 0]
 
-id_full = lower(join(local.delimiter, local.labels))
-id_md5  = md5(local.id_full)
-# Truncates ID to given max length, suffixed by 6 character hash of ID for disambiguation 
-id_short = (var.id_max_length <= 6 ?
-substr(local.id_md5, 0, var.id_max_length) :
-"${replace(substr(local.id_full, 0, var.id_max_length - 6), "/-$/", "")}-${substr(local.id_md5, 0, 5)}")
-id = var.id_max_length != 0 && length(local.id_full) > var.id_max_length ? local.id_short : local.id_full
+  id_full = lower(join(local.delimiter, local.labels))
+  id_md5  = md5(local.id_full)
+  # Truncates ID to given max length, suffixed by 6 character hash of ID for disambiguation 
+  id_short = (var.id_max_length <= 6 ?
+    substr(local.id_md5, 0, var.id_max_length) :
+  "${replace(substr(local.id_full, 0, var.id_max_length - 6), "/-$/", "")}-${substr(local.id_md5, 0, 5)}")
+  id = var.id_max_length != 0 && length(local.id_full) > var.id_max_length ? local.id_short : local.id_full
 
 
   # Context of this label to pass to other label modules

--- a/main.tf
+++ b/main.tf
@@ -56,13 +56,13 @@ locals {
 
   labels = [for l in local.label_order : local.id_context[l] if length(local.id_context[l]) > 0]
 
-  full_id = lower(join(local.delimiter, local.labels))
-  id_md5  = md5(local.full_id)
+  id_full = lower(join(local.delimiter, local.labels))
+  id_md5  = md5(local.id_full)
   # Truncates ID to given max length, suffixed by 6 character hash of ID for disambiguation 
   id_short = (var.max_id_length <= 6 ?
     substr(local.id_md5, 0, var.max_id_length) :
-  "${replace(substr(local.full_id, 0, var.max_id_length - 6), "/-$/", "")}-${substr(local.id_md5, 0, 5)}")
-  id = var.max_id_length != 0 && length(local.full_id) > var.max_id_length ? local.id_short : local.full_id
+  "${replace(substr(local.id_full, 0, var.max_id_length - 6), "/-$/", "")}-${substr(local.id_md5, 0, 5)}")
+  id = var.max_id_length != 0 && length(local.id_full) > var.max_id_length ? local.id_short : local.id_full
 
 
   # Context of this label to pass to other label modules

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,11 @@
 output "id" {
   value       = local.enabled ? local.id : ""
-  description = "Disambiguated ID"
+  description = "Disambiguated ID restricted to max_id_length"
+}
+
+output "full_id" {
+  value       = local.enabled ? local.full_id : ""
+  description = "Disambiguated ID not restricted to max_id_length"
 }
 
 output "name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
 output "id" {
   value       = local.enabled ? local.id : ""
-  description = "Disambiguated ID restricted to max_id_length"
+  description = "Disambiguated ID restricted to id_max_length"
 }
 
 output "id_full" {
   value       = local.enabled ? local.id_full : ""
-  description = "Disambiguated ID not restricted to max_id_length"
+  description = "Disambiguated ID not restricted to id_max_length"
 }
 
 output "name" {
@@ -57,4 +57,3 @@ output "label_order" {
   value       = local.label_order
   description = "The naming order of the id output and Name tag"
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,8 +3,8 @@ output "id" {
   description = "Disambiguated ID restricted to max_id_length"
 }
 
-output "full_id" {
-  value       = local.enabled ? local.full_id : ""
+output "id_full" {
+  value       = local.enabled ? local.id_full : ""
   description = "Disambiguated ID not restricted to max_id_length"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -94,3 +94,8 @@ variable "regex_replace_chars" {
   description = "Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed"
 }
 
+variable "max_id_length" {
+  type        = number
+  default     = 0
+  description = "Specify max length of output id result, or 0 for unrestricted length"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -97,5 +97,5 @@ variable "regex_replace_chars" {
 variable "max_id_length" {
   type        = number
   default     = 0
-  description = "Specify max length of output id result, or 0 for unrestricted length"
+  description = "Specify the max length of the `id` output, or 0 for unrestricted length"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -94,7 +94,7 @@ variable "regex_replace_chars" {
   description = "Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed"
 }
 
-variable "max_id_length" {
+variable "id_max_length" {
   type        = number
   default     = 0
   description = "Specify the max length of the `id` output, or 0 for unrestricted length"


### PR DESCRIPTION
## what
* Adds a new optional variable `max_id_length`, that when set to a value greater than 0 will limit the length of ID output to given value. 
* The truncated ID is still disambiguated by suffixing the first 5 characters of the md5 hash of the full ID.
* The full ID will still be available as a new output `full_id`. 
* The default value of `max_id_length` is 0, so that the change is not breaking any existing usages.

## why
* Many resources have a max allowed length of names, such as aws_lb and aws_alb_target_group (32 characters), aws_iam_role (64 characters). Setting the `max_id_length` variable ensures that the max length is never exceeded, no matter the number of included attributes.

## references
* Closes #93 
