### PR TITLE
Include all context inputs as normalized outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ No provider.
 |------|-------------|
 | additional\_tag\_map | The merged additional\_tag\_map |
 | attributes | List of attributes |
-| context | Merged but otherwise unmodified input to this module, to be use as context input to other modules.<br>Note: this version will have null values as defaults, not the values actually used as defaults. |
+| context | Merged but otherwise unmodified input to this module, to be used as context input to other modules.<br>Note: this version will have null values as defaults, not the values actually used as defaults. |
 | delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
 | enabled | True if module is enabled, false otherwise |
 | environment | Normalized environment |

--- a/README.md
+++ b/README.md
@@ -672,16 +672,20 @@ No provider.
 
 | Name | Description |
 |------|-------------|
+| additional\_tag\_map | The merged additional\_tag\_map |
 | attributes | List of attributes |
-| context | Merged but otherwise unmodified input to this module, to be use as context input to other modules. |
+| context | Merged but otherwise unmodified input to this module, to be use as context input to other modules.<br>Note: this version will have null values as defaults, not the values actually used as defaults. |
 | delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
+| enabled | Normalized enabled |
 | environment | Normalized environment |
 | id | Disambiguated ID restricted to `id_length_limit` characters in total |
 | id\_full | Disambiguated ID not restricted in length |
-| label\_order | The naming order of the id output and Name tag |
+| id\_length\_limit | The id\_length\_limit actually used to create the ID, with `0` meaning unlimited |
+| label\_order | The naming order actually used to create the ID |
 | name | Normalized name |
 | namespace | Normalized namespace |
 | normalized\_context | Normalized context of this module |
+| regex\_replace\_chars | The regex\_replace\_chars actually used to create the ID |
 | stage | Normalized stage |
 | tags | Normalized Tag map |
 | tags\_as\_list\_of\_maps | Additional tags as a list of maps, which can be used in several AWS resources |

--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ No provider.
 | attributes | List of attributes |
 | context | Merged but otherwise unmodified input to this module, to be use as context input to other modules.<br>Note: this version will have null values as defaults, not the values actually used as defaults. |
 | delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
-| enabled | Normalized enabled |
+| enabled | True if module is enabled, false otherwise |
 | environment | Normalized environment |
 | id | Disambiguated ID restricted to `id_length_limit` characters in total |
 | id\_full | Disambiguated ID not restricted in length |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -32,7 +32,7 @@ No provider.
 |------|-------------|
 | additional\_tag\_map | The merged additional\_tag\_map |
 | attributes | List of attributes |
-| context | Merged but otherwise unmodified input to this module, to be use as context input to other modules.<br>Note: this version will have null values as defaults, not the values actually used as defaults. |
+| context | Merged but otherwise unmodified input to this module, to be used as context input to other modules.<br>Note: this version will have null values as defaults, not the values actually used as defaults. |
 | delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
 | enabled | True if module is enabled, false otherwise |
 | environment | Normalized environment |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -34,7 +34,7 @@ No provider.
 | attributes | List of attributes |
 | context | Merged but otherwise unmodified input to this module, to be use as context input to other modules.<br>Note: this version will have null values as defaults, not the values actually used as defaults. |
 | delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
-| enabled | Normalized enabled |
+| enabled | True if module is enabled, false otherwise |
 | environment | Normalized environment |
 | id | Disambiguated ID restricted to `id_length_limit` characters in total |
 | id\_full | Disambiguated ID not restricted in length |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,16 +30,20 @@ No provider.
 
 | Name | Description |
 |------|-------------|
+| additional\_tag\_map | The merged additional\_tag\_map |
 | attributes | List of attributes |
-| context | Merged but otherwise unmodified input to this module, to be use as context input to other modules. |
+| context | Merged but otherwise unmodified input to this module, to be use as context input to other modules.<br>Note: this version will have null values as defaults, not the values actually used as defaults. |
 | delimiter | Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes` |
+| enabled | Normalized enabled |
 | environment | Normalized environment |
 | id | Disambiguated ID restricted to `id_length_limit` characters in total |
 | id\_full | Disambiguated ID not restricted in length |
-| label\_order | The naming order of the id output and Name tag |
+| id\_length\_limit | The id\_length\_limit actually used to create the ID, with `0` meaning unlimited |
+| label\_order | The naming order actually used to create the ID |
 | name | Normalized name |
 | namespace | Normalized namespace |
 | normalized\_context | Normalized context of this module |
+| regex\_replace\_chars | The regex\_replace\_chars actually used to create the ID |
 | stage | Normalized stage |
 | tags | Normalized Tag map |
 | tags\_as\_list\_of\_maps | Additional tags as a list of maps, which can be used in several AWS resources |

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -44,12 +44,12 @@ variable "context" {
     label_order         = []
     id_length_limit     = null
   }
-  description = <<EOT
-Single object for setting entire context at once.
-See description of individual variables for details.
-Leave string and numeric variables as `null` to use default value.
-Individual variable settings (non-null) override settings in context object,
-except for attributes, tags, and additional_tag_map, which are merged.
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
 EOT
 }
 
@@ -68,7 +68,7 @@ variable "namespace" {
 variable "environment" {
   type        = string
   default     = null
-  description = "Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT'"
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
 }
 
 variable "stage" {
@@ -86,7 +86,10 @@ variable "name" {
 variable "delimiter" {
   type        = string
   default     = null
-  description = "Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`"
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+EOT
 }
 
 variable "attributes" {
@@ -104,34 +107,36 @@ variable "tags" {
 variable "additional_tag_map" {
   type        = map(string)
   default     = {}
-  description = "Additional tags for appending to each tag map"
+  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
 }
 
 variable "label_order" {
   type        = list(string)
   default     = null
-  description = "The naming order of the id output and Name tag"
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+EOT
 }
 
 variable "regex_replace_chars" {
   type        = string
   default     = null
-  description = <<EOT
-Regex to replace chars with empty string in
-`namespace`, `environment`, `stage` and `name`.
-If not set, "/[^a-zA-Z0-9-]/" is used to remove
-all characters other than hyphens, letters and digits.
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
 EOT
 }
 
 variable "id_length_limit" {
   type        = number
   default     = null
-  description = <<EOT
-Limit `id` to this many characters.
-Set to `0` for unlimited length.
-Set to `null` for default, which is `0`.
-Does not affect `id_full`.
+  description = <<-EOT
+    Limit `id` to this many characters.
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
 EOT
 }
 

--- a/examples/complete/label6f.tf
+++ b/examples/complete/label6f.tf
@@ -4,6 +4,7 @@ module "label6f" {
   delimiter       = "~"
   id_length_limit = 0
 
+  # Use values from tfvars
   context = module.this.context
 }
 

--- a/examples/complete/label6t.tf
+++ b/examples/complete/label6t.tf
@@ -1,6 +1,8 @@
 module "label6t" {
   source = "../../"
 
+  # Use values from tfvars,
+  # specifically: complete.auto.tfvars
   context = module.this.context
 }
 

--- a/exports/context.tf
+++ b/exports/context.tf
@@ -4,6 +4,15 @@
 # Cloud Posse's standard configuration inputs suitable for passing
 # to Cloud Posse modules.
 #
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
 # ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
 # All other instances of this file should be a copy of that one
 #
@@ -38,12 +47,12 @@ variable "context" {
     label_order         = []
     id_length_limit     = null
   }
-  description = <<EOT
-Single object for setting entire context at once.
-See description of individual variables for details.
-Leave string and numeric variables as `null` to use default value.
-Individual variable settings (non-null) override settings in context object,
-except for attributes, tags, and additional_tag_map, which are merged.
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
 EOT
 }
 
@@ -80,9 +89,9 @@ variable "name" {
 variable "delimiter" {
   type        = string
   default     = null
-  description = <<EOT
-Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
-Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
 EOT
 }
 
@@ -107,30 +116,30 @@ variable "additional_tag_map" {
 variable "label_order" {
   type        = list(string)
   default     = null
-  description = <<EOT
-The naming order of the id output and Name tag.
-Defaults to ["namespace", "environment", "stage", "name", "attributes"].
-You can omit any of the 5 elements, but at least one must be present.
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
 EOT
 }
 
 variable "regex_replace_chars" {
   type        = string
   default     = null
-  description = <<EOT
-Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
-If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
 EOT
 }
 
 variable "id_length_limit" {
   type        = number
   default     = null
-  description = <<EOT
-Limit `id` to this many characters.
-Set to `0` for unlimited length.
-Set to `null` for default, which is `0`.
-Does not affect `id_full`.
+  description = <<-EOT
+    Limit `id` to this many characters.
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
 EOT
 }
 
@@ -144,7 +153,7 @@ EOT
 # for example, `module.this.context.enabled`
 #
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.0"
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.1"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/main.tf
+++ b/main.tf
@@ -105,12 +105,12 @@ locals {
     namespace           = local.namespace
     environment         = local.environment
     stage               = local.stage
+    delimiter           = local.delimiter
     attributes          = local.attributes
     tags                = local.tags
-    delimiter           = local.delimiter
+    additional_tag_map  = local.additional_tag_map
     label_order         = local.label_order
     regex_replace_chars = local.regex_replace_chars
-    additional_tag_map  = local.additional_tag_map
     id_length_limit     = local.id_length_limit
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -81,7 +81,7 @@ output "normalized_context" {
 output "context" {
   value       = local.input
   description = <<-EOT
-  Merged but otherwise unmodified input to this module, to be use as context input to other modules.
+  Merged but otherwise unmodified input to this module, to be used as context input to other modules.
   Note: this version will have null values as defaults, not the values actually used as defaults.
 EOT
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,9 +8,9 @@ output "id_full" {
   description = "Disambiguated ID not restricted in length"
 }
 
-output "name" {
-  value       = local.enabled ? local.name : ""
-  description = "Normalized name"
+output "enabled" {
+  value       = local.enabled
+  description = "True if module is enabled, false otherwise"
 }
 
 output "namespace" {
@@ -18,19 +18,19 @@ output "namespace" {
   description = "Normalized namespace"
 }
 
-output "stage" {
-  value       = local.enabled ? local.stage : ""
-  description = "Normalized stage"
-}
-
 output "environment" {
   value       = local.enabled ? local.environment : ""
   description = "Normalized environment"
 }
 
-output "attributes" {
-  value       = local.enabled ? local.attributes : []
-  description = "List of attributes"
+output "name" {
+  value       = local.enabled ? local.name : ""
+  description = "Normalized name"
+}
+
+output "stage" {
+  value       = local.enabled ? local.stage : ""
+  description = "Normalized stage"
 }
 
 output "delimiter" {
@@ -38,14 +38,34 @@ output "delimiter" {
   description = "Delimiter between `namespace`, `environment`, `stage`, `name` and `attributes`"
 }
 
+output "attributes" {
+  value       = local.enabled ? local.attributes : []
+  description = "List of attributes"
+}
+
 output "tags" {
   value       = local.enabled ? local.tags : {}
   description = "Normalized Tag map"
 }
 
+output "additional_tag_map" {
+  value       = local.additional_tag_map
+  description = "The merged additional_tag_map"
+}
+
 output "label_order" {
   value       = local.label_order
-  description = "The naming order of the id output and Name tag"
+  description = "The naming order actually used to create the ID"
+}
+
+output "regex_replace_chars" {
+  value       = local.regex_replace_chars
+  description = "The regex_replace_chars actually used to create the ID"
+}
+
+output "id_length_limit" {
+  value       = local.id_length_limit
+  description = "The id_length_limit actually used to create the ID, with `0` meaning unlimited"
 }
 
 output "tags_as_list_of_maps" {
@@ -60,6 +80,9 @@ output "normalized_context" {
 
 output "context" {
   value       = local.input
-  description = "Merged but otherwise unmodified input to this module, to be use as context input to other modules."
+  description = <<-EOT
+  Merged but otherwise unmodified input to this module, to be use as context input to other modules.
+  Note: this version will have null values as defaults, not the values actually used as defaults.
+EOT
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -27,12 +27,12 @@ variable "context" {
     label_order         = []
     id_length_limit     = null
   }
-  description = <<EOT
-Single object for setting entire context at once.
-See description of individual variables for details.
-Leave string and numeric variables as `null` to use default value.
-Individual variable settings (non-null) override settings in context object,
-except for attributes, tags, and additional_tag_map, which are merged.
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
 EOT
 }
 
@@ -69,9 +69,9 @@ variable "name" {
 variable "delimiter" {
   type        = string
   default     = null
-  description = <<EOT
-Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
-Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
 EOT
 }
 
@@ -96,29 +96,29 @@ variable "additional_tag_map" {
 variable "label_order" {
   type        = list(string)
   default     = null
-  description = <<EOT
-The naming order of the id output and Name tag.
-Defaults to ["namespace", "environment", "stage", "name", "attributes"].
-You can omit any of the 5 elements, but at least one must be present.
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
 EOT
 }
 
 variable "regex_replace_chars" {
   type        = string
   default     = null
-  description = <<EOT
-Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
-If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
 EOT
 }
 
 variable "id_length_limit" {
   type        = number
   default     = null
-  description = <<EOT
-Limit `id` to this many characters.
-Set to `0` for unlimited length.
-Set to `null` for default, which is `0`.
-Does not affect `id_full`.
+  description = <<-EOT
+    Limit `id` to this many characters.
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
 EOT
 }


### PR DESCRIPTION
### Enhancement to #99 

## what
- Include all context inputs as normalized outputs

## why
- Enable a consistent pattern of `module.this.context.var` to reference the input value with `null` defaults and `module.this.var` to reference the normalized value with nulls replaced by actual default values.

## references
- See #99: Standardize `context` for input and chaining
