### PR TITLE
Remove symlink, polish documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -690,6 +691,7 @@ No provider.
 | tags | Normalized Tag map |
 | tags\_as\_list\_of\_maps | Additional tags as a list of maps, which can be used in several AWS resources |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -48,3 +49,4 @@ No provider.
 | tags | Normalized Tag map |
 | tags\_as\_list\_of\_maps | Additional tags as a list of maps, which can be used in several AWS resources |
 
+<!-- markdownlint-restore -->

--- a/examples/autoscalinggroup/context.tf
+++ b/examples/autoscalinggroup/context.tf
@@ -1,1 +1,172 @@
-../../exports/context.tf
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+variable "context" {
+  type = object({
+    enabled             = bool
+    namespace           = string
+    environment         = string
+    stage               = string
+    name                = string
+    delimiter           = string
+    attributes          = list(string)
+    tags                = map(string)
+    additional_tag_map  = map(string)
+    regex_replace_chars = string
+    label_order         = list(string)
+    id_length_limit     = number
+  })
+  default = {
+    enabled             = true
+    namespace           = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+EOT
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters.
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
+EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf
+
+#
+# Ensure all variables above are includes in input to module "this" below
+#
+# Modules should access the whole context as `module.this.context`
+# and access individual variables as `module.this.context.<var>`,
+# for example, `module.this.context.enabled`
+#
+module "this" {
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.1"
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+
+  context = var.context
+}

--- a/examples/autoscalinggroup/context.tf
+++ b/examples/autoscalinggroup/context.tf
@@ -1,3 +1,12 @@
+# DO NOT COPY THIS FILE
+#
+# This is a specially modified version of this file, since it is used to test
+# the unpublished version of this module. Normally you should use a
+# copy of the file as explained below.
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
 #
 # Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
 # and then place it in your Terraform module to automatically get
@@ -13,11 +22,28 @@
 # For example, when using defaults, `module.this.context.delimiter`
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
-# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
-# All other instances of this file should be a copy of that one
-#
+
+module "this" {
+  source = "../.."
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+
+  context = var.context
+}
 
 # Copy contents of cloudposse/terraform-null-label/variables.tf here
+
 variable "context" {
   type = object({
     enabled             = bool
@@ -53,7 +79,7 @@ variable "context" {
     Leave string and numeric variables as `null` to use default value.
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
-EOT
+  EOT
 }
 
 variable "enabled" {
@@ -92,7 +118,7 @@ variable "delimiter" {
   description = <<-EOT
     Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
     Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
-EOT
+  EOT
 }
 
 variable "attributes" {
@@ -120,7 +146,7 @@ variable "label_order" {
     The naming order of the id output and Name tag.
     Defaults to ["namespace", "environment", "stage", "name", "attributes"].
     You can omit any of the 5 elements, but at least one must be present.
-EOT
+  EOT
 }
 
 variable "regex_replace_chars" {
@@ -129,7 +155,7 @@ variable "regex_replace_chars" {
   description = <<-EOT
     Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
     If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
-EOT
+  EOT
 }
 
 variable "id_length_limit" {
@@ -140,33 +166,7 @@ variable "id_length_limit" {
     Set to `0` for unlimited length.
     Set to `null` for default, which is `0`.
     Does not affect `id_full`.
-EOT
+  EOT
 }
 
 #### End of copy of cloudposse/terraform-null-label/variables.tf
-
-#
-# Ensure all variables above are includes in input to module "this" below
-#
-# Modules should access the whole context as `module.this.context`
-# and access individual variables as `module.this.context.<var>`,
-# for example, `module.this.context.enabled`
-#
-module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.1"
-
-  enabled             = var.enabled
-  namespace           = var.namespace
-  environment         = var.environment
-  stage               = var.stage
-  name                = var.name
-  delimiter           = var.delimiter
-  attributes          = var.attributes
-  tags                = var.tags
-  additional_tag_map  = var.additional_tag_map
-  label_order         = var.label_order
-  regex_replace_chars = var.regex_replace_chars
-  id_length_limit     = var.id_length_limit
-
-  context = var.context
-}

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -4,17 +4,46 @@
 # the unpublished version of this module. Normally you should use a
 # copy of the file as explained below.
 #
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
 #
 # Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
 # and then place it in your Terraform module to automatically get
 # Cloud Posse's standard configuration inputs suitable for passing
 # to Cloud Posse modules.
 #
-# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
-# All other instances of this file should be a copy of that one
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
 
+module "this" {
+  source = "../.."
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+
+  context = var.context
+}
+
 # Copy contents of cloudposse/terraform-null-label/variables.tf here
+
 variable "context" {
   type = object({
     enabled             = bool
@@ -50,7 +79,7 @@ variable "context" {
     Leave string and numeric variables as `null` to use default value.
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
-EOT
+  EOT
 }
 
 variable "enabled" {
@@ -89,7 +118,7 @@ variable "delimiter" {
   description = <<-EOT
     Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
     Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
-EOT
+  EOT
 }
 
 variable "attributes" {
@@ -117,7 +146,7 @@ variable "label_order" {
     The naming order of the id output and Name tag.
     Defaults to ["namespace", "environment", "stage", "name", "attributes"].
     You can omit any of the 5 elements, but at least one must be present.
-EOT
+  EOT
 }
 
 variable "regex_replace_chars" {
@@ -126,7 +155,7 @@ variable "regex_replace_chars" {
   description = <<-EOT
     Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
     If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
-EOT
+  EOT
 }
 
 variable "id_length_limit" {
@@ -137,34 +166,7 @@ variable "id_length_limit" {
     Set to `0` for unlimited length.
     Set to `null` for default, which is `0`.
     Does not affect `id_full`.
-EOT
+  EOT
 }
 
 #### End of copy of cloudposse/terraform-null-label/variables.tf
-
-#
-# Ensure all variables above are includes in input to module "this" below
-#
-# Modules should access the whole context as `module.this.context`
-# and access individual variables as `module.this.context.<var>`,
-# for example, `module.this.context.enabled`
-#
-module "this" {
-  // source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.0"
-  source = "../.."
-
-  enabled             = var.enabled
-  namespace           = var.namespace
-  environment         = var.environment
-  stage               = var.stage
-  name                = var.name
-  delimiter           = var.delimiter
-  attributes          = var.attributes
-  tags                = var.tags
-  additional_tag_map  = var.additional_tag_map
-  label_order         = var.label_order
-  regex_replace_chars = var.regex_replace_chars
-  id_length_limit     = var.id_length_limit
-
-  context = var.context
-}

--- a/exports/context.tf
+++ b/exports/context.tf
@@ -74,7 +74,7 @@ variable "context" {
     Leave string and numeric variables as `null` to use default value.
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
-EOT
+  EOT
 }
 
 variable "enabled" {
@@ -113,7 +113,7 @@ variable "delimiter" {
   description = <<-EOT
     Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
     Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
-EOT
+  EOT
 }
 
 variable "attributes" {
@@ -141,7 +141,7 @@ variable "label_order" {
     The naming order of the id output and Name tag.
     Defaults to ["namespace", "environment", "stage", "name", "attributes"].
     You can omit any of the 5 elements, but at least one must be present.
-EOT
+  EOT
 }
 
 variable "regex_replace_chars" {
@@ -150,7 +150,7 @@ variable "regex_replace_chars" {
   description = <<-EOT
     Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
     If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
-EOT
+  EOT
 }
 
 variable "id_length_limit" {
@@ -161,7 +161,7 @@ variable "id_length_limit" {
     Set to `0` for unlimited length.
     Set to `null` for default, which is `0`.
     Does not affect `id_full`.
-EOT
+  EOT
 }
 
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/exports/context.tf
+++ b/exports/context.tf
@@ -1,4 +1,8 @@
 #
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
 # Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
 # and then place it in your Terraform module to automatically get
 # Cloud Posse's standard configuration inputs suitable for passing
@@ -13,11 +17,28 @@
 # For example, when using defaults, `module.this.context.delimiter`
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
-# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
-# All other instances of this file should be a copy of that one
-#
+
+module "this" {
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+
+  context = var.context
+}
 
 # Copy contents of cloudposse/terraform-null-label/variables.tf here
+
 variable "context" {
   type = object({
     enabled             = bool
@@ -144,29 +165,3 @@ EOT
 }
 
 #### End of copy of cloudposse/terraform-null-label/variables.tf
-
-#
-# Ensure all variables above are includes in input to module "this" below
-#
-# Modules should access the whole context as `module.this.context`
-# and access individual variables as `module.this.context.<var>`,
-# for example, `module.this.context.enabled`
-#
-module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.1"
-
-  enabled             = var.enabled
-  namespace           = var.namespace
-  environment         = var.environment
-  stage               = var.stage
-  name                = var.name
-  delimiter           = var.delimiter
-  attributes          = var.attributes
-  tags                = var.tags
-  additional_tag_map  = var.additional_tag_map
-  label_order         = var.label_order
-  regex_replace_chars = var.regex_replace_chars
-  id_length_limit     = var.id_length_limit
-
-  context = var.context
-}

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "context" {
     Leave string and numeric variables as `null` to use default value.
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
-EOT
+  EOT
 }
 
 variable "enabled" {
@@ -72,7 +72,7 @@ variable "delimiter" {
   description = <<-EOT
     Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
     Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
-EOT
+  EOT
 }
 
 variable "attributes" {
@@ -100,7 +100,7 @@ variable "label_order" {
     The naming order of the id output and Name tag.
     Defaults to ["namespace", "environment", "stage", "name", "attributes"].
     You can omit any of the 5 elements, but at least one must be present.
-EOT
+  EOT
 }
 
 variable "regex_replace_chars" {
@@ -109,7 +109,7 @@ variable "regex_replace_chars" {
   description = <<-EOT
     Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
     If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
-EOT
+  EOT
 }
 
 variable "id_length_limit" {
@@ -120,5 +120,5 @@ variable "id_length_limit" {
     Set to `0` for unlimited length.
     Set to `null` for default, which is `0`.
     Does not affect `id_full`.
-EOT
+  EOT
 }


### PR DESCRIPTION
## what

- Replace symbolic link to `context.tf` (`examples/autoscalinggroup/context.tf`) with copy of file
- Move module to top of `context.tf` and clean up documentation comments inside the file

## why

- Terraform clones the whole repo, not just the top directory, and the symbolic link causes problems for some IDEs 
- Module contains version number and source URL, which should be at the top of the file

