### PR TITLE
Restore "this" name to context module

### DIFF
--- a/exports/context.tf
+++ b/exports/context.tf
@@ -19,7 +19,7 @@
 #
 
 
-module "label" {
+module "this" {
   source  = "cloudposse/label/null"
   version = "0.22.0" // requires Terraform >= 0.12.26
 


### PR DESCRIPTION
## what
- Restore "this" name to context module

## why
- #110 accidentally changed the name to "label". All modules that use it depend on it being called "this"