### PR TITLE
auto pinning version in exports/context.tf on new release

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,51 @@
+pull_request_rules:
+  - name: "approve automated PRs that have passed checks"
+    conditions:
+      - "check-success~=test/bats"
+      - "check-success~=test/readme"
+      - "check-success~=test/terratest"
+      - "base=master"
+      - "author=cloudpossebot"
+      - "head~=auto-update/.*"
+    actions:
+      review:
+        type: "APPROVE"
+        message: "We've automatically approved this PR because the checks from the automated Pull Request have passed."
+
+  - name: "merge automated PRs when approved and tests pass"
+    conditions:
+      - "check-success~=test/bats"
+      - "check-success~=test/readme"
+      - "check-success~=test/terratest"
+      - "base=master"
+      - "head~=auto-update/.*"
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "#commented-reviews-by=0"
+      - "base=master"
+      - "author=cloudpossebot"
+    actions:
+      merge:
+        method: "squash"
+
+  - name: "delete the head branch after merge"
+    conditions:
+      - "merged"
+    actions:
+      delete_head_branch: {}
+
+  - name: "ask to resolve conflict"
+    conditions:
+      - "conflict"
+    actions:
+      comment:
+        message: "This pull request is now in conflicts. Could you fix it @{{author}}? 🙏"
+
+  - name: "remove outdated reviews"
+    conditions:
+      - "base=master"
+    actions:
+      dismiss_reviews:
+        changes_requested: true
+        approved: true
+        message: "This Pull Request has been updated, so we're dismissing all reviews."

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,17 +3,25 @@ name: auto-release
 on:
   push:
     branches:
-    - master
+      - master
 
 jobs:
   semver:
     runs-on: ubuntu-latest
     steps:
-    # Drafts your next Release notes as Pull Requests are merged into "master"
-    - uses: release-drafter/release-drafter@v5
-      with:
-        publish: false
-        prerelease: false
-        config-name: auto-release.yml
-      env:
-        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      - uses: actions-ecosystem/action-get-merged-pull-request@v1
+        id: get-merged-pull-request
+        with:
+          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        # Check if 'do-not-release' label set, skip if so. Used for auto-update 'exports/context.tf' version pinning.
+        if: "!contains(steps.get-merged-pull-request.outputs.labels, 'do-not-release')"
+        with:
+          # TODO: set to true when will be sure it works as needed
+          publish: false
+          prerelease: false
+          config-name: auto-release.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/auto-update-version.yml
+++ b/.github/workflows/auto-update-version.yml
@@ -1,0 +1,56 @@
+name: "auto-update-version-pinning"
+on:
+  release:
+    types: [published]
+
+jobs:
+  update:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    container: cloudposse/testing.cloudposse.co:latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Update exports/context.tf version pinning
+        shell: bash
+        id: update
+        env:
+          LATEST_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          echo "Checking if exports/context.tf match replace pattern exactly once"
+          [[ $(grep -Ec '(\s*version\s*\=\s*\")([0-9]+\.[0-9]+\.[0-9]+)(\")' exports/context.tf) = 1 ]]
+          echo "Checking that LATEST_TAG fetched properly: '$LATEST_TAG'"
+          echo $LATEST_TAG | grep -Eq '^\d+\.\d+\.\d+$'
+          echo "Replacing exports/context.tf version pinning with new: $LATEST_TAG"
+          sed -Ei 's/(\s*version\s*\=\s*\")([0-9]+\.[0-9]+\.[0-9]+)(\")/\1'$LATEST_TAG'\3/g' exports/context.tf
+
+      - name: Create Pull Request
+        uses: cloudposse/actions/github/create-pull-request@0.20.0
+        id: create-pr
+        with:
+          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          commit-message: Update 'exports/context.tf' with most recent release of this repo.
+          title: Update 'exports/context.tf' version pinning
+          body: |-
+            ## what
+            This is an auto-generated PR that updates 'exports/context.tf' with most recent release of this repo.
+
+            ## why
+            As 'exports/context.tf' is used by foreign modules it should be pinned to most recent release of this repo.
+
+          branch: auto-update/exports-context.tf
+          base: master
+          delete-branch: true
+          labels: |
+            auto-update
+            context-pinning
+            do-not-release
+
+      - name: Add chatops command to run tests
+        uses: cloudposse/actions/github/create-or-update-comment@0.22.0
+        with:
+          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ steps.create-pr.outputs.pull-request-number }}
+          body: "/test all"

--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 


### PR DESCRIPTION
## what
* Automatically update `exports/context.tf` version pinning

## why
* We currently cut a new release on every merge to master in `terraform-null-label`. After that we have to update `exports/context.tf` file to point to new release. This update should not trigger auto-release again (using PR label `do-not-release`)
