### PR TITLE
Allow multiple truncated versions of a label

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,25 @@ Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leadin
 
 
 
+## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+| Benchmark | Description |
+|--------|---------------|
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
+| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
+| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+
+
+
 ## Usage
 
 

--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ No provider.
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| id\_lengths | Create variants of `id` limited to these many characters.<br>By default, no variants are created.<br>The length-limited `id` variants are available as the `id_trunc` output map.<br>For example, variable `id_lengths = [8,16]` results in output `id_trunc` = {8 => "...", 16 => "..." }.<br>This functionality generally supersedes `id_length_limit`. | `list(number)` | `[]` | no |
 | label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
@@ -721,6 +722,7 @@ No provider.
 | id | Disambiguated ID restricted to `id_length_limit` characters in total |
 | id\_full | Disambiguated ID not restricted in length |
 | id\_length\_limit | The id\_length\_limit actually used to create the ID, with `0` meaning unlimited |
+| id\_trunc | Disambiguated ID restricted to character lengths specified by `id_lengths` variable.<br>For example, variable `id_lengths = [8,16]` results in output `id_trunc` = {8 => "...", 16 => "..." }. |
 | label\_order | The naming order actually used to create the ID |
 | name | Normalized name |
 | namespace | Normalized namespace |

--- a/README.md
+++ b/README.md
@@ -103,44 +103,6 @@ Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leadin
 
 
 
-## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
-
-Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
-
-| Benchmark | Description |
-|--------|---------------|
-| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
-| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
-| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
-| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
-| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
-| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
-| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
-| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=SOC2)| Service Organization Control 2 Compliance |
-| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
-| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
-
-
-
-## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
-
-Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
-
-| Benchmark | Description |
-|--------|---------------|
-| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
-| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
-| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
-| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
-| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
-| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
-| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
-| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=SOC2)| Service Organization Control 2 Compliance |
-| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
-| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
-
-
-
 ## Usage
 
 
@@ -726,13 +688,21 @@ Available targets:
 
 No provider.
 
+## Modules
+
+No Modules.
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, additional\_tag\_map, and id\_lengths, which are<br>merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "id_lengths": [],<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
@@ -769,7 +739,6 @@ No provider.
 | stage | Normalized stage |
 | tags | Normalized Tag map |
 | tags\_as\_list\_of\_maps | Additional tags as a list of maps, which can be used in several AWS resources |
-
 <!-- markdownlint-restore -->
 
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leadin
 
 
 
+## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+| Benchmark | Description |
+|--------|---------------|
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
+| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
+| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-null-label/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-null-label&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+
+
+
 ## Usage
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,13 +9,21 @@
 
 No provider.
 
+## Modules
+
+No Modules.
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, additional\_tag\_map, and id\_lengths, which are<br>merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "id_lengths": [],<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
@@ -52,5 +60,4 @@ No provider.
 | stage | Normalized stage |
 | tags | Normalized Tag map |
 | tags\_as\_list\_of\_maps | Additional tags as a list of maps, which can be used in several AWS resources |
-
 <!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -20,6 +20,7 @@ No provider.
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| id\_lengths | Create variants of `id` limited to these many characters.<br>By default, no variants are created.<br>The length-limited `id` variants are available as the `id_trunc` output map.<br>For example, variable `id_lengths = [8,16]` results in output `id_trunc` = {8 => "...", 16 => "..." }.<br>This functionality generally supersedes `id_length_limit`. | `list(number)` | `[]` | no |
 | label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
@@ -42,6 +43,7 @@ No provider.
 | id | Disambiguated ID restricted to `id_length_limit` characters in total |
 | id\_full | Disambiguated ID not restricted in length |
 | id\_length\_limit | The id\_length\_limit actually used to create the ID, with `0` meaning unlimited |
+| id\_trunc | Disambiguated ID restricted to character lengths specified by `id_lengths` variable.<br>For example, variable `id_lengths = [8,16]` results in output `id_trunc` = {8 => "...", 16 => "..." }. |
 | label\_order | The naming order actually used to create the ID |
 | name | Normalized name |
 | namespace | Normalized namespace |

--- a/examples/autoscalinggroup/context.tf
+++ b/examples/autoscalinggroup/context.tf
@@ -60,6 +60,7 @@ variable "context" {
     id_length_limit     = number
     label_key_case      = string
     label_value_case    = string
+    id_lengths          = list(number)
   })
   default = {
     enabled             = true
@@ -76,13 +77,15 @@ variable "context" {
     id_length_limit     = null
     label_key_case      = null
     label_value_case    = null
+    id_lengths          = []
   }
   description = <<-EOT
     Single object for setting entire context at once.
     See description of individual variables for details.
     Leave string and numeric variables as `null` to use default value.
     Individual variable settings (non-null) override settings in context object,
-    except for attributes, tags, and additional_tag_map, which are merged.
+    except for attributes, tags, additional_tag_map, and id_lengths, which are
+    merged.
   EOT
 
   validation {
@@ -93,6 +96,11 @@ variable "context" {
   validation {
     condition     = var.context["label_value_case"] == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
     error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+
+  validation {
+    condition     = length([for i in var.context["id_lengths"] : i if i == null]) == 0
+    error_message = "You cannot specify null in context[\"id_lengths\"]."
   }
 }
 
@@ -210,6 +218,24 @@ variable "label_value_case" {
   validation {
     condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
     error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "id_lengths" {
+  type        = list(number)
+  default     = []
+  description = <<-EOT
+    Create variants of `id` limited to these many characters.
+    By default, no variants are created.
+    The length-limited `id` variants are available as the `id_trunc` output map.
+    For example, variable `id_lengths = [8,16]` results in output `id_trunc` = {8 => "...", 16 => "..." }.
+    This functionality generally supersedes `id_length_limit`.
+  EOT
+
+  validation {
+    # As of tf0.13 you can't use contains() to check for null
+    condition     = length([for i in var.id_lengths : i if i == null]) == 0
+    error_message = "You cannot specify null in var.id_lengths."
   }
 }
 

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -62,6 +62,7 @@ variable "context" {
     id_length_limit     = number
     label_key_case      = string
     label_value_case    = string
+    id_lengths          = list(number)
   })
   default = {
     enabled             = true
@@ -78,13 +79,15 @@ variable "context" {
     id_length_limit     = null
     label_key_case      = null
     label_value_case    = null
+    id_lengths          = []
   }
   description = <<-EOT
     Single object for setting entire context at once.
     See description of individual variables for details.
     Leave string and numeric variables as `null` to use default value.
     Individual variable settings (non-null) override settings in context object,
-    except for attributes, tags, and additional_tag_map, which are merged.
+    except for attributes, tags, additional_tag_map, and id_lengths, which are
+    merged.
   EOT
 
   validation {
@@ -95,6 +98,11 @@ variable "context" {
   validation {
     condition     = var.context["label_value_case"] == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
     error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+
+  validation {
+    condition     = length([for i in var.context["id_lengths"] : i if i == null]) == 0
+    error_message = "You cannot specify null in context[\"id_lengths\"]."
   }
 }
 
@@ -225,6 +233,12 @@ variable "id_lengths" {
     For example, variable `id_lengths = [8,16]` results in output `id_trunc` = {8 => "...", 16 => "..." }.
     This functionality generally supersedes `id_length_limit`.
   EOT
+
+  validation {
+    # As of tf0.13 you can't use contains() to check for null
+    condition     = length([for i in var.id_lengths : i if i == null]) == 0
+    error_message = "You cannot specify null in var.id_lengths."
+  }
 }
 
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -214,4 +214,17 @@ variable "label_value_case" {
     error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
   }
 }
+
+variable "id_lengths" {
+  type        = list(number)
+  default     = []
+  description = <<-EOT
+    Create variants of `id` limited to these many characters.
+    By default, no variants are created.
+    The length-limited `id` variants are available as the `id_trunc` output map.
+    For example, variable `id_lengths = [8,16]` results in output `id_trunc` = {8 => "...", 16 => "..." }.
+    This functionality generally supersedes `id_length_limit`.
+  EOT
+}
+
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/examples/complete/label9.tf
+++ b/examples/complete/label9.tf
@@ -10,11 +10,8 @@ module "label9v" {
   id_lengths  = [10, 15]
 }
 
-output "label9v" {
-  value = {
-    id  = module.label9v.id
-    ids = module.label9v.id_trunc
-  }
+output "label9v_ids" {
+  value = module.label9v.id_trunc
 }
 
 # Context only
@@ -23,11 +20,8 @@ module "label9c" {
   context = module.label9v.context
 }
 
-output "label9c" {
-  value = {
-    id  = module.label9c.id
-    ids = module.label9c.id_trunc
-  }
+output "label9c_ids" {
+  value = module.label9c.id_trunc
 }
 
 # Context and variable
@@ -37,9 +31,6 @@ module "label9cv" {
   id_lengths = [30, 50]
 }
 
-output "label9cv" {
-  value = {
-    id  = module.label9cv.id
-    ids = module.label9cv.id_trunc
-  }
+output "label9cv_ids" {
+  value = module.label9cv.id_trunc
 }

--- a/examples/complete/label9.tf
+++ b/examples/complete/label9.tf
@@ -1,15 +1,45 @@
-module "label9" {
+# Tests for id_lengths
+
+# Variable only
+module "label9v" {
   source      = "../../"
   namespace   = "CloudPosse"
   environment = "UAT"
   stage       = "build"
   name        = "Winston Churchroom"
-  id_lengths  = [10, 15, 30, 50]
+  id_lengths  = [10, 15]
 }
 
-output "label9_truncated_ids" {
+output "label9v" {
   value = {
-    id  = module.label9.id
-    ids = module.label9.id_trunc
+    id  = module.label9v.id
+    ids = module.label9v.id_trunc
+  }
+}
+
+# Context only
+module "label9c" {
+  source  = "../../"
+  context = module.label9v.context
+}
+
+output "label9c" {
+  value = {
+    id  = module.label9c.id
+    ids = module.label9c.id_trunc
+  }
+}
+
+# Context and variable
+module "label9cv" {
+  source     = "../../"
+  context    = module.label9v.context
+  id_lengths = [30, 50]
+}
+
+output "label9cv" {
+  value = {
+    id  = module.label9cv.id
+    ids = module.label9cv.id_trunc
   }
 }

--- a/examples/complete/label9.tf
+++ b/examples/complete/label9.tf
@@ -37,8 +37,8 @@ output "label9cv_ids" {
 
 // No specification, and an old pre-id_lengths context
 module "label9_oldcontext" {
-  source = "../../"
-  context = { for k, v in module.label9c.context : k => v if k != "id_lengths"}
+  source  = "../../"
+  context = { for k, v in module.label9c.context : k => v if k != "id_lengths" }
 }
 
 output "label9_oldcontext_ids" {

--- a/examples/complete/label9.tf
+++ b/examples/complete/label9.tf
@@ -1,0 +1,15 @@
+module "label9" {
+  source      = "../../"
+  namespace   = "CloudPosse"
+  environment = "UAT"
+  stage       = "build"
+  name        = "Winston Churchroom"
+  id_lengths  = [10, 15, 30, 50]
+}
+
+output "label9_truncated_ids" {
+  value = {
+    id  = module.label9.id
+    ids = module.label9.id_trunc
+  }
+}

--- a/examples/complete/label9.tf
+++ b/examples/complete/label9.tf
@@ -34,3 +34,13 @@ module "label9cv" {
 output "label9cv_ids" {
   value = module.label9cv.id_trunc
 }
+
+// No specification, and an old pre-id_lengths context
+module "label9_oldcontext" {
+  source = "../../"
+  context = { for k, v in module.label9c.context : k => v if k != "id_lengths"}
+}
+
+output "label9_oldcontext_ids" {
+  value = module.label9_oldcontext.id_trun
+}

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ locals {
   id_hash_length = local.defaults.id_hash_length
 
   # The values provided by variables supersede the values inherited from the context object,
-  # except for tags and attributes which are merged.
+  # except for the following items which merge: tags, attributes, and id_lengths.
   input = {
     # It would be nice to use coalesce here, but we cannot, because it
     # is an error for all the arguments to coalesce to be empty.
@@ -37,7 +37,7 @@ locals {
     id_length_limit     = var.id_length_limit == null ? var.context.id_length_limit : var.id_length_limit
     label_key_case      = var.label_key_case == null ? lookup(var.context, "label_key_case", null) : var.label_key_case
     label_value_case    = var.label_value_case == null ? lookup(var.context, "label_value_case", null) : var.label_value_case
-    id_lengths          = distinct(concat(var.context.id_lengths, var.id_lengths))
+    id_lengths          = distinct(concat(lookup(var.context, "id_lengths", []), var.id_lengths))
   }
 
 

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ locals {
     id_hash_length      = 5
     label_key_case      = "title"
     label_value_case    = "lower"
+    id_lengths          = []
   }
 
   # So far, we have decided not to allow overriding replacement or id_hash_length
@@ -36,6 +37,7 @@ locals {
     id_length_limit     = var.id_length_limit == null ? var.context.id_length_limit : var.id_length_limit
     label_key_case      = var.label_key_case == null ? lookup(var.context, "label_key_case", null) : var.label_key_case
     label_value_case    = var.label_value_case == null ? lookup(var.context, "label_value_case", null) : var.label_value_case
+    id_lengths          = distinct(concat(var.context.id_lengths, var.id_lengths))
   }
 
 
@@ -72,6 +74,7 @@ locals {
   label_value_case = local.input.label_value_case == null ? local.defaults.label_value_case : local.input.label_value_case
 
   additional_tag_map = merge(var.context.additional_tag_map, var.additional_tag_map)
+  id_lengths         = local.input.id_lengths
 
   tags = merge(local.generated_tags, local.input.tags)
 
@@ -126,9 +129,9 @@ locals {
   id       = local.id_length_limit != 0 && length(local.id_full) > local.id_length_limit ? local.id_short : local.id_full
 
   # Custom truncated lengths
-  ids_truncated_length_limit = { for length in var.id_lengths : length => length - local.id_truncated_suffix_length }
-  ids_truncated              = { for length in var.id_lengths : length => local.ids_truncated_length_limit[length] <= 0 ? "" : "${trimsuffix(substr(local.id_full, 0, local.ids_truncated_length_limit[length]), local.delimiter)}${local.delimiter}" }
-  ids                        = { for length in var.id_lengths : length => length(local.id_full) > length ? substr("${local.ids_truncated[length]}${local.id_hash}", 0, length) : local.id_full }
+  ids_truncated_length_limit = { for length in local.id_lengths : length => length - local.id_truncated_suffix_length }
+  ids_truncated              = { for length in local.id_lengths : length => local.ids_truncated_length_limit[length] <= 0 ? "" : "${trimsuffix(substr(local.id_full, 0, local.ids_truncated_length_limit[length]), local.delimiter)}${local.delimiter}" }
+  ids                        = { for length in local.id_lengths : length => length(local.id_full) > length ? substr("${local.ids_truncated[length]}${local.id_hash}", 0, length) : local.id_full }
 
   # Context of this label to pass to other label modules
   output_context = {
@@ -146,6 +149,7 @@ locals {
     id_length_limit     = local.id_length_limit
     label_key_case      = local.label_key_case
     label_value_case    = local.label_value_case
+    id_lengths          = local.id_lengths
   }
 
 }

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,8 @@ locals {
   # Create a truncated ID if needed
   delimiter_length = length(local.delimiter)
   # Calculate length of normal part of ID, leaving room for delimiter and hash
-  id_truncated_length_limit = local.id_length_limit - (local.id_hash_length + local.delimiter_length)
+  id_truncated_suffix_length = local.id_hash_length + local.delimiter_length
+  id_truncated_length_limit  = local.id_length_limit - local.id_truncated_suffix_length
   # Truncate the ID and ensure a single (not double) trailing delimiter
   id_truncated = local.id_truncated_length_limit <= 0 ? "" : "${trimsuffix(substr(local.id_full, 0, local.id_truncated_length_limit), local.delimiter)}${local.delimiter}"
   # Support usages that disallow numeric characters. Would prefer tr 0-9 q-z but Terraform does not support it.
@@ -124,6 +125,10 @@ locals {
   id_short = substr("${local.id_truncated}${local.id_hash}", 0, local.id_length_limit)
   id       = local.id_length_limit != 0 && length(local.id_full) > local.id_length_limit ? local.id_short : local.id_full
 
+  # Custom truncated lengths
+  ids_truncated_length_limit = { for length in var.id_lengths : length => length - local.id_truncated_suffix_length }
+  ids_truncated              = { for length in var.id_lengths : length => local.ids_truncated_length_limit[length] <= 0 ? "" : "${trimsuffix(substr(local.id_full, 0, local.ids_truncated_length_limit[length]), local.delimiter)}${local.delimiter}" }
+  ids                        = { for length in var.id_lengths : length => length(local.id_full) > length ? substr("${local.ids_truncated[length]}${local.id_hash}", 0, length) : local.id_full }
 
   # Context of this label to pass to other label modules
   output_context = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,14 @@ output "id_full" {
   description = "Disambiguated ID not restricted in length"
 }
 
+output "id_trunc" {
+  value       = { for length in var.id_lengths : length => local.ids[length] }
+  description = <<-EOT
+    Disambiguated ID restricted to character lengths specified by `id_lengths` variable.
+    For example, variable `id_lengths = [8,16]` results in output `id_trunc` = {8 => "...", 16 => "..." }.
+  EOT
+}
+
 output "enabled" {
   value       = local.enabled
   description = "True if module is enabled, false otherwise"
@@ -85,4 +93,3 @@ output "context" {
   Note: this version will have null values as defaults, not the values actually used as defaults.
 EOT
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ output "id_full" {
 }
 
 output "id_trunc" {
-  value       = { for length in var.id_lengths : length => local.ids[length] }
+  value       = { for length in local.id_lengths : length => local.ids[length] }
   description = <<-EOT
     Disambiguated ID restricted to character lengths specified by `id_lengths` variable.
     For example, variable `id_lengths = [8,16]` results in output `id_trunc` = {8 => "...", 16 => "..." }.

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -290,4 +290,28 @@ func TestExamplesComplete(t *testing.T) {
 
 	assert.Exactly(t, label8nExpectedTags, label8nTags, "generated tags are different from expected")
 	assert.Exactly(t, label8nTags, label8nContextTags, "tags and context tags should be equal")
+
+	label9vIds := terraform.OutputMap(t, terraformOptions, "label9v_ids")
+	label9vExpectedIds := map[string]string{
+		"10": "clou-32ec8",
+		"15": "cloudposs-32ec8",
+	}
+	assert.Exactly(t, label9vExpectedIds, label9vIds, "label9v ids are different from expected")
+
+	label9cIds := terraform.OutputMap(t, terraformOptions, "label9c_ids")
+	label9cExpectedIds := map[string]string{
+		"10": "clou-32ec8",
+		"15": "cloudposs-32ec8",
+	}
+	assert.Exactly(t, label9cExpectedIds, label9cIds, "label9c ids are different from expected")
+
+	label9cvIds := terraform.OutputMap(t, terraformOptions, "label9cv_ids")
+	label9cvExpectedIds := map[string]string{
+		"10": "clou-32ec8",
+		"15": "cloudposs-32ec8",
+		"30": "cloudposse-uat-build-win-32ec8",
+		"50": "cloudposse-uat-build-winstonchurchroom",
+	}
+	assert.Exactly(t, label9cvExpectedIds, label9cvIds, "label9cv ids are different from expected")
+
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -314,4 +314,7 @@ func TestExamplesComplete(t *testing.T) {
 	}
 	assert.Exactly(t, label9cvExpectedIds, label9cvIds, "label9cv ids are different from expected")
 
+	label9oldcontextIds := terraform.OutputMap(t, terraformOptions, "label9cv_ids")
+	label9oldcontextExpectedIds := map[string]string{}
+	assert.Exactly(t, label9oldcontextExpectedIds, label9oldcontextIds, "label9oldcontext ids are different from expected")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,13 +15,15 @@ variable "context" {
     id_length_limit     = null
     label_key_case      = null
     label_value_case    = null
+    id_lengths          = []
   }
   description = <<-EOT
     Single object for setting entire context at once.
     See description of individual variables for details.
     Leave string and numeric variables as `null` to use default value.
     Individual variable settings (non-null) override settings in context object,
-    except for attributes, tags, and additional_tag_map, which are merged.
+    except for attributes, tags, additional_tag_map, and id_lengths, which are
+    merged.
   EOT
 
   validation {
@@ -32,6 +34,11 @@ variable "context" {
   validation {
     condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
     error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+
+  validation {
+    condition     = length([for i in var.context["id_lengths"] : i if i == null]) == 0
+    error_message = "You cannot specify null in context[\"id_lengths\"]."
   }
 }
 
@@ -166,4 +173,10 @@ variable "id_lengths" {
     For example, variable `id_lengths = [8,16]` results in output `id_trunc` = {8 => "...", 16 => "..." }.
     This functionality generally supersedes `id_length_limit`.
   EOT
+
+  validation {
+    # As of tf0.13 you can't use contains() to check for null
+    condition     = length([for i in var.id_lengths : i if i == null]) == 0
+    error_message = "You cannot specify null in var.id_lengths."
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -155,3 +155,15 @@ variable "label_value_case" {
     error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
   }
 }
+
+variable "id_lengths" {
+  type        = list(number)
+  default     = []
+  description = <<-EOT
+    Create variants of `id` limited to these many characters.
+    By default, no variants are created.
+    The length-limited `id` variants are available as the `id_trunc` output map.
+    For example, variable `id_lengths = [8,16]` results in output `id_trunc` = {8 => "...", 16 => "..." }.
+    This functionality generally supersedes `id_length_limit`.
+  EOT
+}


### PR DESCRIPTION
Truncated forms of id_full which are always available. This is useful
when you want to use the same label for several resources with different
length restrictions.

Closes #117.