### PR TITLE
Add required_tags variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,10 +659,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.26 |
+| external | ~> 2.0.0 |
 
 ## Providers
 
-No provider.
+| Name | Version |
+|------|---------|
+| external | ~> 2.0.0 |
 
 ## Inputs
 
@@ -670,7 +673,7 @@ No provider.
 |------|-------------|------|---------|:--------:|
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, additional\_tag\_map, and required\_tags, which<br>are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    required_tags       = list(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "required_tags": [],<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
@@ -679,6 +682,7 @@ No provider.
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| required\_tags | A list of tag keys that must be set. A runtime error during plan/apply will be raised if any are not. | `list(string)` | `[]` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 
@@ -794,7 +798,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,10 +4,13 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.26 |
+| external | ~> 2.0.0 |
 
 ## Providers
 
-No provider.
+| Name | Version |
+|------|---------|
+| external | ~> 2.0.0 |
 
 ## Inputs
 
@@ -15,7 +18,7 @@ No provider.
 |------|-------------|------|---------|:--------:|
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, additional\_tag\_map, and required\_tags, which<br>are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    required_tags       = list(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "required_tags": [],<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
@@ -24,6 +27,7 @@ No provider.
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| required\_tags | A list of tag keys that must be set. A runtime error during plan/apply will be raised if any are not. | `list(string)` | `[]` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,7 @@ variable "context" {
     attributes          = list(string)
     tags                = map(string)
     additional_tag_map  = map(string)
+    required_tags       = list(string)
     regex_replace_chars = string
     label_order         = list(string)
     id_length_limit     = number
@@ -23,6 +24,7 @@ variable "context" {
     attributes          = []
     tags                = {}
     additional_tag_map  = {}
+    required_tags       = []
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
@@ -32,7 +34,8 @@ variable "context" {
     See description of individual variables for details.
     Leave string and numeric variables as `null` to use default value.
     Individual variable settings (non-null) override settings in context object,
-    except for attributes, tags, and additional_tag_map, which are merged.
+    except for attributes, tags, additional_tag_map, and required_tags, which
+    are merged.
   EOT
 }
 
@@ -91,6 +94,12 @@ variable "additional_tag_map" {
   type        = map(string)
   default     = {}
   description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+}
+
+variable "required_tags" {
+  type        = list(string)
+  default     = []
+  description = "A list of tag keys that must be set. A runtime error during plan/apply will be raised if any are not."
 }
 
 variable "label_order" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,7 @@
 terraform {
   required_version = ">= 0.12.26"
 }
+
+provider "external" {
+  version = "~> 2.0.0"
+}


### PR DESCRIPTION
We can only validate the required tags exist during the plan phase, so this isn't quite as elegant as you'd hope, and the error messages are a little weird looking.

The addition of a new context field makes this a breaking change.

Fixes #74.

<details>
<summary>Examples using Terraform console</summary>

```bash
# No required_tags set
$ terraform console
> local.required_tags
[]
> exit

# Setting required tags with variable
$ terraform console -var 'required_tags=["foo", "bar"]'
> local.required_tags
[
  "foo",
  "bar",
]
> exit

# Setting required tags with variable and context
$ terraform console -var 'required_tags=["foo", "bar"]' -var 'context={additional_tag_map=null,attributes=null,delimiter=null,enabled=true,environment=null,id_length_limit=null,label_order=null,name=null,namespace=null,regex_replace_chars=null,stage=null,tags=null,foo=null,required_tags=["apple", "orange"]}'
> local.required_tags
[
  "apple",
  "orange",
  "foo",
  "bar",
]
> exit

# Setting duplicate required tags with variable and context
$ terraform console -var 'required_tags=["foo", "bar"]' -var 'context={additional_tag_map=null,attributes=null,delimiter=null,enabled=true,environment=null,id_length_limit=null,label_order=null,name=null,namespace=null,regex_replace_chars=null,stage=null,tags=null,foo=null,required_tags=["foo", "bar"]}'
> local.required_tags
[
  "foo",
  "bar",
]
> exit
```
</details>