### PR TITLE
Bridgecrew compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
+**/.terraform.lock.hcl
 
 # .tfvars files
 *.tfvars

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ you can exclude environment and the label `id` will look like `{namespace}-{stag
 - If you want the attributes in a different order, you can specify that, too, with the `label_order` list.
 - You can set a maximum length for the name, and the module will create a unique name that fits within that length.
 - You can control the letter case of the generated labels which make up the `id` using `var.label_value_case`.
-- The labels are also exported as tags. You can control the case of the tag names (keys) using `var.label_tag_case`.
+- The labels are also exported as tags. You can control the case of the tag names (keys) using `var.label_key_case`.
 
 It's recommended to use one `terraform-null-label` module for every unique resource of a given resource type.
 For example, if you have 10 instances, there should be 10 different labels.

--- a/README.yaml
+++ b/README.yaml
@@ -34,7 +34,7 @@ description: |-
   - If you want the attributes in a different order, you can specify that, too, with the `label_order` list.
   - You can set a maximum length for the name, and the module will create a unique name that fits within that length.
   - You can control the letter case of the generated labels which make up the `id` using `var.label_value_case`.
-  - The labels are also exported as tags. You can control the case of the tag names (keys) using `var.label_tag_case`.
+  - The labels are also exported as tags. You can control the case of the tag names (keys) using `var.label_key_case`.
 
   It's recommended to use one `terraform-null-label` module for every unique resource of a given resource type.
   For example, if you have 10 instances, there should be 10 different labels.

--- a/examples/autoscalinggroup/main.tf
+++ b/examples/autoscalinggroup/main.tf
@@ -28,6 +28,11 @@ resource "aws_launch_template" "default" {
     resource_type = "volume"
     tags          = module.label.tags
   }
+
+  # Bridgecrew compliance: Ensure Instance Metadata Service Version 1 is not enabled (BC_AWS_GENERAL_31)
+  metadata_options {
+    http_tokens = "required"
+  }
 }
 
 ######################

--- a/examples/autoscalinggroup/main.tf
+++ b/examples/autoscalinggroup/main.tf
@@ -31,6 +31,9 @@ resource "aws_launch_template" "default" {
     tags          = module.label.tags
   }
 
+  # Bridgecrew BC_AWS_GENERAL_26
+  tags = module.label.tags
+
   # Bridgecrew compliance: Ensure Instance Metadata Service Version 1 is not enabled (BC_AWS_GENERAL_31)
   metadata_options {
     http_tokens = "required"

--- a/examples/autoscalinggroup/main.tf
+++ b/examples/autoscalinggroup/main.tf
@@ -23,9 +23,11 @@ resource "aws_launch_template" "default" {
     enabled = false
   }
 
-  # terraform-null-label example used here: Set tags on volumes
+  # terraform-null-label example used here: Set tags on everything that can be tagged
   tag_specifications {
-    resource_type = "volume"
+    for_each = ["instance", "volume", "elastic-gpu", "spot-instance-request"]
+
+    resource_type = each.value
     tags          = module.label.tags
   }
 


### PR DESCRIPTION
## what
- Resolve Bridgecrew compliance complaint about example Autoscaling Group (BC_AWS_GENERAL_31)
- Fix typo in README
- Include Terraform lock file in `.gitignore`

## why
- Get clean Bridgecrew badge
- Correct confusing error
- Ensure lock files are not checked into GitHub

## note
The PR can and should be merged into `master` to update README and Bridgecrew without triggering a new release/version. These changes have no effect on the actual module in use and a release will create unnecessary ripple effects. However, merging to `master` will update the README and badges, so is worthwhile, and the changes will move forward into the next release.
