### PR TITLE
Add a 'static_tags' option to disable automatic merging of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "static_tags": false,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "suppress_tags": [],<br>  "tags": {}<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
@@ -731,7 +731,7 @@ No resources.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_static_tags"></a> [static\_tags](#input\_static\_tags) | Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags | `bool` | `null` | no |
+| <a name="input_suppress_tags"></a> [suppress\_tags](#input\_suppress\_tags) | A list of tags that should not be automatically added to the 'tags' output (Workaround for allowing AWS `default_tags` without always showing updates terraform-provider-aws#18311) | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -753,7 +753,7 @@ No resources.
 | <a name="output_normalized_context"></a> [normalized\_context](#output\_normalized\_context) | Normalized context of this module |
 | <a name="output_regex_replace_chars"></a> [regex\_replace\_chars](#output\_regex\_replace\_chars) | The regex\_replace\_chars actually used to create the ID |
 | <a name="output_stage"></a> [stage](#output\_stage) | Normalized stage |
-| <a name="output_static_tags"></a> [static\_tags](#output\_static\_tags) | True if tags have not been modified by this module, false otherwise |
+| <a name="output_suppress_tags"></a> [suppress\_tags](#output\_suppress\_tags) | A list of tags that should not be automatically added to the 'tags' output (Workaround for allowing AWS `default_tags` without always showing updates terraform-provider-aws#18311) |
 | <a name="output_tags"></a> [tags](#output\_tags) | Normalized Tag map |
 | <a name="output_tags_as_list_of_maps"></a> [tags\_as\_list\_of\_maps](#output\_tags\_as\_list\_of\_maps) | Additional tags as a list of maps, which can be used in several AWS resources |
 <!-- markdownlint-restore -->

--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "static_tags": false,<br>  "tags": {}<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
@@ -731,6 +731,7 @@ No resources.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_static_tags"></a> [static\_tags](#input\_static\_tags) | Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags | `bool` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -752,6 +753,7 @@ No resources.
 | <a name="output_normalized_context"></a> [normalized\_context](#output\_normalized\_context) | Normalized context of this module |
 | <a name="output_regex_replace_chars"></a> [regex\_replace\_chars](#output\_regex\_replace\_chars) | The regex\_replace\_chars actually used to create the ID |
 | <a name="output_stage"></a> [stage](#output\_stage) | Normalized stage |
+| <a name="output_static_tags"></a> [static\_tags](#output\_static\_tags) | True if tags have not been modified by this module, false otherwise |
 | <a name="output_tags"></a> [tags](#output\_tags) | Normalized Tag map |
 | <a name="output_tags_as_list_of_maps"></a> [tags\_as\_list\_of\_maps](#output\_tags\_as\_list\_of\_maps) | Additional tags as a list of maps, which can be used in several AWS resources |
 <!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -23,7 +23,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "static_tags": false,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "suppress_tags": [],<br>  "tags": {}<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
@@ -35,7 +35,7 @@ No resources.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_static_tags"></a> [static\_tags](#input\_static\_tags) | Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags | `bool` | `null` | no |
+| <a name="input_suppress_tags"></a> [suppress\_tags](#input\_suppress\_tags) | A list of tags that should not be automatically added to the 'tags' output (Workaround for allowing AWS `default_tags` without always showing updates terraform-provider-aws#18311) | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -57,7 +57,7 @@ No resources.
 | <a name="output_normalized_context"></a> [normalized\_context](#output\_normalized\_context) | Normalized context of this module |
 | <a name="output_regex_replace_chars"></a> [regex\_replace\_chars](#output\_regex\_replace\_chars) | The regex\_replace\_chars actually used to create the ID |
 | <a name="output_stage"></a> [stage](#output\_stage) | Normalized stage |
-| <a name="output_static_tags"></a> [static\_tags](#output\_static\_tags) | True if tags have not been modified by this module, false otherwise |
+| <a name="output_suppress_tags"></a> [suppress\_tags](#output\_suppress\_tags) | A list of tags that should not be automatically added to the 'tags' output (Workaround for allowing AWS `default_tags` without always showing updates terraform-provider-aws#18311) |
 | <a name="output_tags"></a> [tags](#output\_tags) | Normalized Tag map |
 | <a name="output_tags_as_list_of_maps"></a> [tags\_as\_list\_of\_maps](#output\_tags\_as\_list\_of\_maps) | Additional tags as a list of maps, which can be used in several AWS resources |
 <!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -23,7 +23,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "static_tags": false,<br>  "tags": {}<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
@@ -35,6 +35,7 @@ No resources.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_static_tags"></a> [static\_tags](#input\_static\_tags) | Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags | `bool` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -56,6 +57,7 @@ No resources.
 | <a name="output_normalized_context"></a> [normalized\_context](#output\_normalized\_context) | Normalized context of this module |
 | <a name="output_regex_replace_chars"></a> [regex\_replace\_chars](#output\_regex\_replace\_chars) | The regex\_replace\_chars actually used to create the ID |
 | <a name="output_stage"></a> [stage](#output\_stage) | Normalized stage |
+| <a name="output_static_tags"></a> [static\_tags](#output\_static\_tags) | True if tags have not been modified by this module, false otherwise |
 | <a name="output_tags"></a> [tags](#output\_tags) | Normalized Tag map |
 | <a name="output_tags_as_list_of_maps"></a> [tags\_as\_list\_of\_maps](#output\_tags\_as\_list\_of\_maps) | Additional tags as a list of maps, which can be used in several AWS resources |
 <!-- markdownlint-restore -->

--- a/examples/autoscalinggroup/context.tf
+++ b/examples/autoscalinggroup/context.tf
@@ -27,7 +27,7 @@ module "this" {
   source = "../.."
 
   enabled             = var.enabled
-  static_tags         = var.static_tags
+  suppress_tags         = var.suppress_tags
   namespace           = var.namespace
   environment         = var.environment
   stage               = var.stage
@@ -48,7 +48,7 @@ module "this" {
 variable "context" {
   type = object({
     enabled             = bool
-    static_tags         = bool
+    suppress_tags         = list(string)
     namespace           = string
     environment         = string
     stage               = string
@@ -65,7 +65,7 @@ variable "context" {
   })
   default = {
     enabled             = true
-    static_tags         = false
+    suppress_tags         = []
     namespace           = null
     environment         = null
     stage               = null
@@ -105,10 +105,10 @@ variable "enabled" {
   description = "Set to false to prevent the module from creating any resources"
 }
 
-variable "static_tags" {
-  type        = bool
-  default     = null
-  description = "Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags"
+variable "suppress_tags" {
+  type        = list(string)
+  default     = []
+  description = "A list of tags that should not be automatically added to the 'tags' output (Workaround for allowing AWS `default_tags` without always showing updates terraform-provider-aws#18311)"
 }
 
 variable "namespace" {

--- a/examples/autoscalinggroup/context.tf
+++ b/examples/autoscalinggroup/context.tf
@@ -27,6 +27,7 @@ module "this" {
   source = "../.."
 
   enabled             = var.enabled
+  static_tags         = var.static_tags
   namespace           = var.namespace
   environment         = var.environment
   stage               = var.stage
@@ -47,6 +48,7 @@ module "this" {
 variable "context" {
   type = object({
     enabled             = bool
+    static_tags         = bool
     namespace           = string
     environment         = string
     stage               = string
@@ -63,6 +65,7 @@ variable "context" {
   })
   default = {
     enabled             = true
+    static_tags         = false
     namespace           = null
     environment         = null
     stage               = null
@@ -100,6 +103,12 @@ variable "enabled" {
   type        = bool
   default     = null
   description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "static_tags" {
+  type        = bool
+  default     = null
+  description = "Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags"
 }
 
 variable "namespace" {

--- a/examples/autoscalinggroup/context.tf
+++ b/examples/autoscalinggroup/context.tf
@@ -27,7 +27,7 @@ module "this" {
   source = "../.."
 
   enabled             = var.enabled
-  suppress_tags         = var.suppress_tags
+  suppress_tags       = var.suppress_tags
   namespace           = var.namespace
   environment         = var.environment
   stage               = var.stage
@@ -48,7 +48,7 @@ module "this" {
 variable "context" {
   type = object({
     enabled             = bool
-    suppress_tags         = list(string)
+    suppress_tags       = list(string)
     namespace           = string
     environment         = string
     stage               = string
@@ -65,7 +65,7 @@ variable "context" {
   })
   default = {
     enabled             = true
-    suppress_tags         = []
+    suppress_tags       = []
     namespace           = null
     environment         = null
     stage               = null

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -27,7 +27,7 @@ module "this" {
   source = "../.."
 
   enabled             = var.enabled
-  suppress_tags         = var.suppress_tags
+  suppress_tags       = var.suppress_tags
   namespace           = var.namespace
   environment         = var.environment
   stage               = var.stage
@@ -50,7 +50,7 @@ module "this" {
 variable "context" {
   type = object({
     enabled             = bool
-    suppress_tags         = list(string)
+    suppress_tags       = list(string)
     namespace           = string
     environment         = string
     stage               = string
@@ -67,7 +67,7 @@ variable "context" {
   })
   default = {
     enabled             = true
-    suppress_tags         = []
+    suppress_tags       = []
     namespace           = null
     environment         = null
     stage               = null

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -27,6 +27,7 @@ module "this" {
   source = "../.."
 
   enabled             = var.enabled
+  static_tags         = var.static_tags
   namespace           = var.namespace
   environment         = var.environment
   stage               = var.stage
@@ -49,6 +50,7 @@ module "this" {
 variable "context" {
   type = object({
     enabled             = bool
+    static_tags         = bool
     namespace           = string
     environment         = string
     stage               = string
@@ -65,6 +67,7 @@ variable "context" {
   })
   default = {
     enabled             = true
+    static_tags         = false
     namespace           = null
     environment         = null
     stage               = null
@@ -102,6 +105,12 @@ variable "enabled" {
   type        = bool
   default     = null
   description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "static_tags" {
+  type        = bool
+  default     = null
+  description = "Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags"
 }
 
 variable "namespace" {

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -27,7 +27,7 @@ module "this" {
   source = "../.."
 
   enabled             = var.enabled
-  static_tags         = var.static_tags
+  suppress_tags         = var.suppress_tags
   namespace           = var.namespace
   environment         = var.environment
   stage               = var.stage
@@ -50,7 +50,7 @@ module "this" {
 variable "context" {
   type = object({
     enabled             = bool
-    static_tags         = bool
+    suppress_tags         = list(string)
     namespace           = string
     environment         = string
     stage               = string
@@ -67,7 +67,7 @@ variable "context" {
   })
   default = {
     enabled             = true
-    static_tags         = false
+    suppress_tags         = []
     namespace           = null
     environment         = null
     stage               = null
@@ -107,10 +107,10 @@ variable "enabled" {
   description = "Set to false to prevent the module from creating any resources"
 }
 
-variable "static_tags" {
-  type        = bool
-  default     = null
-  description = "Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags"
+variable "suppress_tags" {
+  type        = list(string)
+  default     = []
+  description = "A list of tags that should not be automatically added to the 'tags' output (Workaround for allowing AWS `default_tags` without always showing updates terraform-provider-aws#18311)"
 }
 
 variable "namespace" {

--- a/examples/complete/label9.tf
+++ b/examples/complete/label9.tf
@@ -1,11 +1,11 @@
 module "label9" {
-  source           = "../../"
-  enabled          = true
-  static_tags      = true
+  source      = "../../"
+  enabled     = true
+  static_tags = true
 
   tags = {
     "kubernetes.io/cluster/" = "shared"
-    "City" = "Norwich"
+    "City"                   = "Norwich"
   }
 }
 

--- a/examples/complete/label9.tf
+++ b/examples/complete/label9.tf
@@ -1,0 +1,45 @@
+module "label9" {
+  source           = "../../"
+  enabled          = true
+  static_tags      = true
+
+  tags = {
+    "kubernetes.io/cluster/" = "shared"
+    "City" = "Norwich"
+  }
+}
+
+module "label9_context" {
+  source = "../../"
+
+  context = module.label9.context
+}
+
+output "label9_context_id" {
+  value = module.label9_context.id
+}
+
+output "label9_context_context" {
+  value = module.label9_context.context
+}
+
+// debug
+output "label9_context_normalized_context" {
+  value = module.label9_context.normalized_context
+}
+
+output "label9_context_tags" {
+  value = module.label9_context.tags
+}
+
+output "label9_id" {
+  value = module.label9.id
+}
+
+output "label9_context" {
+  value = module.label9.context
+}
+
+output "label9_tags" {
+  value = module.label9.tags
+}

--- a/examples/complete/label9.tf
+++ b/examples/complete/label9.tf
@@ -1,7 +1,9 @@
 module "label9" {
-  source      = "../../"
-  enabled     = true
-  static_tags = true
+  source           = "../../"
+  enabled          = true
+  suppress_tags    = ["environment", "stage", "name"]
+  environment      = "demo"
+  name             = "red"
 
   tags = {
     "kubernetes.io/cluster/" = "shared"

--- a/examples/complete/label9.tf
+++ b/examples/complete/label9.tf
@@ -1,9 +1,9 @@
 module "label9" {
-  source           = "../../"
-  enabled          = true
-  suppress_tags    = ["environment", "stage", "name"]
-  environment      = "demo"
-  name             = "red"
+  source        = "../../"
+  enabled       = true
+  suppress_tags = ["environment", "stage", "name"]
+  environment   = "demo"
+  name          = "red"
 
   tags = {
     "kubernetes.io/cluster/" = "shared"

--- a/examples/complete/label9a.tf
+++ b/examples/complete/label9a.tf
@@ -1,0 +1,47 @@
+module "label9a" {
+  source           = "../../"
+  enabled          = true
+  suppress_tags      = ["environment"]
+  environment     = "demo"
+  name = "red"
+
+  tags = {
+    "kubernetes.io/cluster/" = "shared"
+    "City" = "Norwich"
+  }
+}
+
+module "label9a_context" {
+  source = "../../"
+
+  context = module.label9a.context
+}
+
+output "label9a_context_id" {
+  value = module.label9a_context.id
+}
+
+output "label9a_context_context" {
+  value = module.label9a_context.context
+}
+
+// debug
+output "label9a_context_normalized_context" {
+  value = module.label9a_context.normalized_context
+}
+
+output "label9a_context_tags" {
+  value = module.label9a_context.tags
+}
+
+output "label9a_id" {
+  value = module.label9a.id
+}
+
+output "label9a_context" {
+  value = module.label9a.context
+}
+
+output "label9a_tags" {
+  value = module.label9a.tags
+}

--- a/examples/complete/label9a.tf
+++ b/examples/complete/label9a.tf
@@ -1,13 +1,13 @@
 module "label9a" {
-  source           = "../../"
-  enabled          = true
-  suppress_tags      = ["environment"]
-  environment     = "demo"
-  name = "red"
+  source        = "../../"
+  enabled       = true
+  suppress_tags = ["environment"]
+  environment   = "demo"
+  name          = "red"
 
   tags = {
     "kubernetes.io/cluster/" = "shared"
-    "City" = "Norwich"
+    "City"                   = "Norwich"
   }
 }
 

--- a/exports/context.tf
+++ b/exports/context.tf
@@ -23,7 +23,7 @@ module "this" {
   version = "0.24.1" # requires Terraform >= 0.13.0
 
   enabled             = var.enabled
-  suppress_tags         = var.suppress_tags
+  suppress_tags       = var.suppress_tags
   namespace           = var.namespace
   environment         = var.environment
   stage               = var.stage
@@ -47,7 +47,7 @@ variable "context" {
   type = any
   default = {
     enabled             = true
-    suppress_tags         = []
+    suppress_tags       = []
     namespace           = null
     environment         = null
     stage               = null

--- a/exports/context.tf
+++ b/exports/context.tf
@@ -23,7 +23,7 @@ module "this" {
   version = "0.24.1" # requires Terraform >= 0.13.0
 
   enabled             = var.enabled
-  static_tags         = var.static_tags
+  suppress_tags         = var.suppress_tags
   namespace           = var.namespace
   environment         = var.environment
   stage               = var.stage
@@ -47,7 +47,7 @@ variable "context" {
   type = any
   default = {
     enabled             = true
-    static_tags         = false
+    suppress_tags         = []
     namespace           = null
     environment         = null
     stage               = null
@@ -87,10 +87,10 @@ variable "enabled" {
   description = "Set to false to prevent the module from creating any resources"
 }
 
-variable "static_tags" {
-  type        = bool
-  default     = null
-  description = "Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags"
+variable "suppress_tags" {
+  type        = list(string)
+  default     = []
+  description = "A list of tags that should not be automatically added to the 'tags' output (Workaround for allowing AWS `default_tags` without always showing updates terraform-provider-aws#18311)"
 }
 
 variable "namespace" {

--- a/exports/context.tf
+++ b/exports/context.tf
@@ -23,6 +23,7 @@ module "this" {
   version = "0.24.1" # requires Terraform >= 0.13.0
 
   enabled             = var.enabled
+  static_tags         = var.static_tags
   namespace           = var.namespace
   environment         = var.environment
   stage               = var.stage
@@ -46,6 +47,7 @@ variable "context" {
   type = any
   default = {
     enabled             = true
+    static_tags         = false
     namespace           = null
     environment         = null
     stage               = null
@@ -83,6 +85,12 @@ variable "enabled" {
   type        = bool
   default     = null
   description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "static_tags" {
+  type        = bool
+  default     = null
+  description = "Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags"
 }
 
 variable "namespace" {

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ locals {
     # It would be nice to use coalesce here, but we cannot, because it
     # is an error for all the arguments to coalesce to be empty.
     enabled     = var.enabled == null ? var.context.enabled : var.enabled
+    static_tags = var.static_tags == null ? var.context.static_tags : var.static_tags
     namespace   = var.namespace == null ? var.context.namespace : var.namespace
     environment = var.environment == null ? var.context.environment : var.environment
     stage       = var.stage == null ? var.context.stage : var.stage
@@ -40,6 +41,7 @@ locals {
 
 
   enabled             = local.input.enabled
+  static_tags         = local.input.static_tags
   regex_replace_chars = coalesce(local.input.regex_replace_chars, local.defaults.regex_replace_chars)
 
   # string_label_names are names of inputs that are strings (not list of strings) used as labels
@@ -73,7 +75,7 @@ locals {
 
   additional_tag_map = merge(var.context.additional_tag_map, var.additional_tag_map)
 
-  tags = merge(local.generated_tags, local.input.tags)
+  tags = local.static_tags ? local.input.tags : merge(local.generated_tags, local.input.tags)
 
   tags_as_list_of_maps = flatten([
     for key in keys(local.tags) : merge(
@@ -128,6 +130,7 @@ locals {
   # Context of this label to pass to other label modules
   output_context = {
     enabled             = local.enabled
+    static_tags         = local.static_tags
     name                = local.name
     namespace           = local.namespace
     environment         = local.environment

--- a/main.tf
+++ b/main.tf
@@ -20,13 +20,13 @@ locals {
   input = {
     # It would be nice to use coalesce here, but we cannot, because it
     # is an error for all the arguments to coalesce to be empty.
-    enabled     = var.enabled == null ? var.context.enabled : var.enabled
+    enabled       = var.enabled == null ? var.context.enabled : var.enabled
     suppress_tags = var.suppress_tags == null ? var.context.suppress_tags : var.suppress_tags
-    namespace   = var.namespace == null ? var.context.namespace : var.namespace
-    environment = var.environment == null ? var.context.environment : var.environment
-    stage       = var.stage == null ? var.context.stage : var.stage
-    name        = var.name == null ? var.context.name : var.name
-    delimiter   = var.delimiter == null ? var.context.delimiter : var.delimiter
+    namespace     = var.namespace == null ? var.context.namespace : var.namespace
+    environment   = var.environment == null ? var.context.environment : var.environment
+    stage         = var.stage == null ? var.context.stage : var.stage
+    name          = var.name == null ? var.context.name : var.name
+    delimiter     = var.delimiter == null ? var.context.delimiter : var.delimiter
     # modules tack on attributes (passed by var) to the end of the list (passed by context)
     attributes = compact(distinct(concat(coalesce(var.context.attributes, []), coalesce(var.attributes, []))))
     tags       = merge(var.context.tags, var.tags)
@@ -41,7 +41,7 @@ locals {
 
 
   enabled             = local.input.enabled
-  suppress_tags         = local.input.suppress_tags
+  suppress_tags       = local.input.suppress_tags
   regex_replace_chars = coalesce(local.input.regex_replace_chars, local.defaults.regex_replace_chars)
 
   # string_label_names are names of inputs that are strings (not list of strings) used as labels
@@ -75,7 +75,7 @@ locals {
 
   additional_tag_map = merge(var.context.additional_tag_map, var.additional_tag_map)
 
-  tags = { for k, v in merge(local.generated_tags, local.input.tags): k => v if ! contains([for i in local.suppress_tags: lower(i)], lower(k)) }
+  tags = { for k, v in merge(local.generated_tags, local.input.tags) : k => v if ! contains([for i in local.suppress_tags : lower(i)], lower(k)) }
 
   tags_as_list_of_maps = flatten([
     for key in keys(local.tags) : merge(
@@ -130,7 +130,7 @@ locals {
   # Context of this label to pass to other label modules
   output_context = {
     enabled             = local.enabled
-    suppress_tags         = local.suppress_tags
+    suppress_tags       = local.suppress_tags
     name                = local.name
     namespace           = local.namespace
     environment         = local.environment

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ locals {
     # It would be nice to use coalesce here, but we cannot, because it
     # is an error for all the arguments to coalesce to be empty.
     enabled     = var.enabled == null ? var.context.enabled : var.enabled
-    static_tags = var.static_tags == null ? var.context.static_tags : var.static_tags
+    suppress_tags = var.suppress_tags == null ? var.context.suppress_tags : var.suppress_tags
     namespace   = var.namespace == null ? var.context.namespace : var.namespace
     environment = var.environment == null ? var.context.environment : var.environment
     stage       = var.stage == null ? var.context.stage : var.stage
@@ -41,7 +41,7 @@ locals {
 
 
   enabled             = local.input.enabled
-  static_tags         = local.input.static_tags
+  suppress_tags         = local.input.suppress_tags
   regex_replace_chars = coalesce(local.input.regex_replace_chars, local.defaults.regex_replace_chars)
 
   # string_label_names are names of inputs that are strings (not list of strings) used as labels
@@ -75,7 +75,7 @@ locals {
 
   additional_tag_map = merge(var.context.additional_tag_map, var.additional_tag_map)
 
-  tags = local.static_tags ? local.input.tags : merge(local.generated_tags, local.input.tags)
+  tags = { for k, v in merge(local.generated_tags, local.input.tags): k => v if ! contains([for i in local.suppress_tags: lower(i)], lower(k)) }
 
   tags_as_list_of_maps = flatten([
     for key in keys(local.tags) : merge(
@@ -130,7 +130,7 @@ locals {
   # Context of this label to pass to other label modules
   output_context = {
     enabled             = local.enabled
-    static_tags         = local.static_tags
+    suppress_tags         = local.suppress_tags
     name                = local.name
     namespace           = local.namespace
     environment         = local.environment

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,7 @@ output "enabled" {
 }
 
 output "static_tags" {
-  value = local.static_tags
+  value       = local.static_tags
   description = "True if tags have not been modified by this module, false otherwise"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,9 +13,9 @@ output "enabled" {
   description = "True if module is enabled, false otherwise"
 }
 
-output "static_tags" {
-  value       = local.static_tags
-  description = "True if tags have not been modified by this module, false otherwise"
+output "suppress_tags" {
+  value       = local.suppress_tags
+  description = "A list of tags that should not be automatically added to the 'tags' output (Workaround for allowing AWS `default_tags` without always showing updates terraform-provider-aws#18311)"
 }
 
 output "namespace" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "enabled" {
   description = "True if module is enabled, false otherwise"
 }
 
+output "static_tags" {
+  value = local.static_tags
+  description = "True if tags have not been modified by this module, false otherwise"
+}
+
 output "namespace" {
   value       = local.enabled ? local.namespace : ""
   description = "Normalized namespace"
@@ -85,4 +90,3 @@ output "context" {
   Note: this version will have null values as defaults, not the values actually used as defaults.
 EOT
 }
-

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -291,14 +291,35 @@ func TestExamplesComplete(t *testing.T) {
 	assert.Exactly(t, label8nExpectedTags, label8nTags, "generated tags are different from expected")
 	assert.Exactly(t, label8nTags, label8nContextTags, "tags and context tags should be equal")
 
-	// Verify that static_tags correctly stops the module from merging new tags and instead uses the statically given ones
+	// Verify that suppress_tags correctly removes tags from the tags output but not context tags
 	label9ExpectedTags := map[string]string{
-			"kubernetes.io/cluster/": "shared",
 			"City": "Norwich",
+			"kubernetes.io/cluster/": "shared",
 	}
 	label9Tags := terraform.OutputMap(t, terraformOptions, "label9_tags")
 	label9ContextTags := terraform.OutputMap(t, terraformOptions, "label9_context_tags")
 
 	assert.Exactly(t, label9ExpectedTags, label9Tags, "generated tags are different from expected")
 	assert.Exactly(t, label9Tags, label9ContextTags, "tags and context tags should be equal")
+
+	label9aExpectedTags := map[string]string{
+		"City": "Norwich",
+		"Name": "demo-red",
+		"kubernetes.io/cluster/": "shared",
+	}
+	label9aTags := terraform.OutputMap(t, terraformOptions, "label9a_tags")
+	assert.Exactly(t, label9aExpectedTags, label9aTags, "generated tags are different from expected")
+
+	label9aExpectedContextTags := map[string]string{
+		"City": "Norwich",
+		"Environment": "demo",
+		"Name": "demo-red",
+		"kubernetes.io/cluster/": "shared",
+	}
+
+	label9aContextTags := terraform.OutputMap(t, terraformOptions, "label9a_context_tags")
+
+	assert.Exactly(t, label9aExpectedContextTags, label9aContextTags, "generated tags are different from expected")
+	assert.NotEqual(t, label9aTags, label9aContextTags, "tags and context tags should NOT be equal if suppress_tags is set")
+
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -290,4 +290,15 @@ func TestExamplesComplete(t *testing.T) {
 
 	assert.Exactly(t, label8nExpectedTags, label8nTags, "generated tags are different from expected")
 	assert.Exactly(t, label8nTags, label8nContextTags, "tags and context tags should be equal")
+
+	// Verify that static_tags correctly stops the module from merging new tags and instead uses the statically given ones
+	label9ExpectedTags := map[string]string{
+			"kubernetes.io/cluster/": "shared",
+			"City": "Norwich",
+	}
+	label9Tags := terraform.OutputMap(t, terraformOptions, "label9_tags")
+	label9ContextTags := terraform.OutputMap(t, terraformOptions, "label9_context_tags")
+
+	assert.Exactly(t, label9ExpectedTags, label9Tags, "generated tags are different from expected")
+	assert.Exactly(t, label9Tags, label9ContextTags, "tags and context tags should be equal")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,7 @@ variable "context" {
   type = any
   default = {
     enabled             = true
-    suppress_tags         = []
+    suppress_tags       = []
     namespace           = null
     environment         = null
     stage               = null

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,7 @@ variable "context" {
   type = any
   default = {
     enabled             = true
-    static_tags         = false
+    suppress_tags         = []
     namespace           = null
     environment         = null
     stage               = null
@@ -42,10 +42,10 @@ variable "enabled" {
   description = "Set to false to prevent the module from creating any resources"
 }
 
-variable "static_tags" {
-  type        = bool
-  default     = null
-  description = "Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags"
+variable "suppress_tags" {
+  type        = list(string)
+  default     = []
+  description = "A list of tags that should not be automatically added to the 'tags' output (Workaround for allowing AWS `default_tags` without always showing updates terraform-provider-aws#18311)"
 }
 
 variable "namespace" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,7 @@ variable "context" {
   type = any
   default = {
     enabled             = true
+    static_tags         = false
     namespace           = null
     environment         = null
     stage               = null
@@ -39,6 +40,12 @@ variable "enabled" {
   type        = bool
   default     = null
   description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "static_tags" {
+  type        = bool
+  default     = null
+  description = "Set to true to prevent the module adding merging additional tags into `var.tags`, for use with precomputed tags"
 }
 
 variable "namespace" {


### PR DESCRIPTION
## what
* Adds a new variable `static_tags`, set to false by default, which stops the module from merging in new tags and instead uses the `tags` variable in the input as-is, including handing it off to other modules as necessary

## why
* Helps avoid https://github.com/hashicorp/terraform-provider-aws/issues/18311
* Being able to precompute labels which are then passed into `cloudposse` modules can be useful in certain circumstances

I have a fork of `terraform-null-label` that removes tags that interfere with provider `default_tags`, but this isn't obeyed by downstream cloudposse modules. This PR should make it possible to pass context in and force null_label to not make any tags, or only make a subset of the tags :)

## references
* https://github.com/hashicorp/terraform-provider-aws/issues/18311


