### PR TITLE
Stop using the "prehistoric" terraform naming for modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,7 +926,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2023 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 
@@ -1013,7 +1013,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-null-label&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-null-label&utm_content=website
@@ -1044,3 +1044,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-null-label
   [share_email]: mailto:?subject=terraform-null-label&body=https://github.com/cloudposse/terraform-null-label
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-null-label?pixel&cs=github&cm=readme&an=terraform-null-label
+<!-- markdownlint-restore -->

--- a/exports/context.tf
+++ b/exports/context.tf
@@ -8,19 +8,19 @@
 # Cloud Posse's standard configuration inputs suitable for passing
 # to Cloud Posse modules.
 #
-# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o naming.tf
 #
-# Modules should access the whole context as `module.this.context`
+# Modules should access the whole context as `module.naming.context`
 # to get the input variables with nulls for defaults,
-# for example `context = module.this.context`,
-# and access individual variables as `module.this.<var>`,
+# for example `context = module.naming.context`,
+# and access individual variables as `module.naming.<var>`,
 # with final values filled in.
 #
-# For example, when using defaults, `module.this.context.delimiter`
-# will be null, and `module.this.delimiter` will be `-` (hyphen).
+# For example, when using defaults, `module.naming.context.delimiter`
+# will be null, and `module.naming.delimiter` will be `-` (hyphen).
 #
 
-module "this" {
+module "naming" {
   source  = "cloudposse/label/null"
   version = "0.25.0" # requires Terraform >= 0.13.0
 


### PR DESCRIPTION
To prevent bad practices by people downloading this file as a bootstrap, it will be a lot better to have a module name not meaningless.

## what
* rename the module and exemples in the file `exports/context.tf`

## why
* Avoid the name `this` which is meaningless, confusing, and was a kind of bad habbit in first ages of terraform.
* Explicit the name of the module by `naming` so you can use it like `module.naming.tags`