### PR TITLE
fix: enabled var should be enforced

### DIFF
--- a/exports/context.tf
+++ b/exports/context.tf
@@ -98,6 +98,11 @@ variable "enabled" {
   type        = bool
   default     = null
   description = "Set to false to prevent the module from creating any resources"
+
+  validation {
+    condition     = var.enabled == null ? true : contains([true, false], var.enabled)
+    error_message = "enabled must be a boolean or null."
+  }
 }
 
 variable "namespace" {

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,11 @@ variable "enabled" {
   type        = bool
   default     = null
   description = "Set to false to prevent the module from creating any resources"
+
+  validation {
+    condition     = var.enabled == null ? true : contains([true, false], var.enabled)
+    error_message = "enabled must be a boolean or null."
+  }
 }
 
 variable "namespace" {


### PR DESCRIPTION
## what
* Today var.enabled accepts strings and numbers, as well as bool and null.

## why
* When you write `enabled = "false"` the boolean conversion translates this to true.
* This enforces strict typing of bool or null.

## references
* n/a

